### PR TITLE
Implement Operación: The Perimeter

### DIFF
--- a/GUIDANCE_AND_EXPLANATIONS.md
+++ b/GUIDANCE_AND_EXPLANATIONS.md
@@ -1,0 +1,208 @@
+# Wi-Fi Hotspot (Chernarus_Beacon) Setup Guide for Raspberry Pi 5
+
+This guide provides instructions for setting up a Wi-Fi hotspot named `rpi` (internally referred to as `Chernarus_Beacon` for thematic purposes) on your Raspberry Pi 5 using the generated configuration files. The hotspot will operate on the `192.168.73.0/24` network, with the Raspberry Pi itself at `192.168.73.1` on the `wlan0` interface.
+
+## Generated Configuration Files:
+
+1.  **`hotspot_config/hostapd.conf`**: Configuration for `hostapd`, the software that creates the wireless access point.
+2.  **`hotspot_config/pihole_custom_dnsmasq.conf`**: DHCP configuration for `dnsmasq` (managed by Pi-hole) to assign IP addresses to devices connecting to the hotspot.
+3.  **`scripts/setup_hotspot_nat.sh`**: A shell script to configure Network Address Translation (NAT) and IP forwarding, allowing hotspot clients to access the internet through the Raspberry Pi's other network connection (e.g., `eth0`).
+
+## I. `hostapd` Configuration (Access Point Setup)
+
+The `hotspot_config/hostapd.conf` file configures the basic parameters of your Wi-Fi hotspot.
+
+**Key Settings:**
+
+*   **`ssid=rpi`**: The name of the Wi-Fi network that will be broadcast.
+*   **`wpa_passphrase=YourStrongPasswordHere`**: The password for the Wi-Fi network.
+*   **`country_code=US`**: The regulatory domain for wireless communication.
+
+**Deployment Steps:**
+
+1.  **IMPORTANT: Change the Wi-Fi Password!**
+    Open `hotspot_config/hostapd.conf` and change `wpa_passphrase=YourStrongPasswordHere` to a strong, unique password.
+
+2.  **Verify Country Code:**
+    In `hotspot_config/hostapd.conf`, check and update the `country_code` (e.g., `GB` for the United Kingdom, `DE` for Germany) to match your physical location. This is important for regulatory compliance.
+
+3.  **Install `hostapd`:**
+    If not already installed, open a terminal on your Raspberry Pi and run:
+    ```bash
+    sudo apt-get update
+    sudo apt-get install -y hostapd
+    ```
+
+4.  **Copy the Configuration File:**
+    Copy the modified `hostapd.conf` file to the `/etc/hostapd/` directory on your Raspberry Pi:
+    ```bash
+    sudo cp hotspot_config/hostapd.conf /etc/hostapd/hostapd.conf
+    ```
+
+5.  **Inform `hostapd` where to find the configuration:**
+    Edit the `hostapd` default configuration file:
+    ```bash
+    sudo nano /etc/default/hostapd
+    ```
+    Find the line `#DAEMON_CONF=""` and change it to:
+    ```
+    DAEMON_CONF="/etc/hostapd/hostapd.conf"
+    ```
+    Save and exit the editor.
+
+6.  **Unmask and Enable `hostapd` Service:**
+    It's common for `hostapd` to be masked by default.
+    ```bash
+    sudo systemctl unmask hostapd
+    sudo systemctl enable hostapd
+    ```
+    You will start `hostapd` later, after configuring networking and DHCP.
+
+## II. DHCP Server Configuration (via Pi-hole/dnsmasq)
+
+**DHCP Choice Explanation:**
+
+For thematic consistency with `StarySobor_RadioPost` (your Pi-hole instance) and to centralize DNS and IP management, these instructions integrate DHCP services for the hotspot directly into Pi-hole. Pi-hole uses `dnsmasq` internally, which is a lightweight DHCP and DNS caching server. By adding a custom configuration file to Pi-hole's `dnsmasq` setup, we can make Pi-hole responsible for assigning IP addresses to devices connecting to the `Chernarus_Beacon` hotspot (`wlan0`). This avoids running a separate DHCP server and ensures that hotspot clients can easily use Pi-hole for DNS.
+
+**Deployment Steps for `pihole_custom_dnsmasq.conf`:**
+
+1.  **Copy the Custom `dnsmasq` Configuration:**
+    Place the generated `hotspot_config/pihole_custom_dnsmasq.conf` file into the `/etc/dnsmasq.d/` directory on your Raspberry Pi (the one running Pi-hole). It's good practice to give it a descriptive name, for example:
+    ```bash
+    sudo cp hotspot_config/pihole_custom_dnsmasq.conf /etc/dnsmasq.d/02-chernarus-hotspot-dhcp.conf
+    ```
+    (The `02-` prefix helps with ordering if you have multiple custom files).
+
+2.  **Restart Pi-hole's FTLDNS Service:**
+    This will make `dnsmasq` pick up the new configuration.
+    ```bash
+    sudo pihole restartdns
+    # OR, if the above command is not found or you prefer systemctl:
+    # sudo systemctl restart pihole-FTL.service
+    ```
+
+3.  **Pi-hole `setupVars.conf` Check (Important):**
+    Ensure Pi-hole's main configuration (`/etc/pihole/setupVars.conf`) does **not** define `PIHOLE_INTERFACE` in a way that would conflict. For example, if `PIHOLE_INTERFACE` is set strictly to `eth0`, Pi-hole might not listen for DHCP requests on `wlan0` even with the custom config.
+    *   The `interface=wlan0` line within your `02-chernarus-hotspot-dhcp.conf` is intended to explicitly tell `dnsmasq` to listen on `wlan0` for DHCP (and DNS) queries for the hotspot.
+    *   If you have `PIHOLE_INTERFACE` set in `setupVars.conf`, and it's *not* set to listen on all interfaces (e.g., `PIHOLE_INTERFACE=`), you might need to remove that specific line or adjust it if issues arise. Often, for Pi-hole to serve DHCP on multiple interfaces, it's best to let `dnsmasq.d` configurations handle the interface specifics.
+
+4.  **Verify in Pi-hole Admin Interface:**
+    *   Navigate to your Pi-hole's admin web interface.
+    *   Go to **Settings > DHCP**.
+    *   Check if the "DHCP server enabled" box is ticked.
+    *   You should see the DHCP range `192.168.73.10` to `192.168.73.200` listed, and it should indicate it's active for `wlan0`.
+    *   If it wasn't previously enabled, or if settings don't appear, you might need to:
+        *   Enable the DHCP server using the Pi-hole GUI.
+        *   If it was already enabled for another interface (e.g., `eth0`), the new configuration should add `wlan0` to its scope. A restart of FTLDNS (`pihole restartdns`) is usually sufficient.
+        *   Ensure "Pi-hole DHCP server" is selected under "DHCP Settings" if you are using Pi-hole as the DHCP server for your main network as well.
+
+## III. Network Configuration (Static IP for `wlan0` and NAT)
+
+Before starting `hostapd`, you need to assign a static IP address to the `wlan0` interface. This IP (`192.168.73.1`) will be the gateway for your hotspot clients.
+
+**Static IP for `wlan0` (using `dhcpcd`):**
+
+Most Raspberry Pi OS versions use `dhcpcd` to manage network interfaces.
+
+1.  Edit the `dhcpcd` configuration file:
+    ```bash
+    sudo nano /etc/dhcpcd.conf
+    ```
+
+2.  Add the following lines to the end of the file. If you have other `interface wlan0` configurations, ensure they don't conflict.
+    ```conf
+    interface wlan0
+    static ip_address=192.168.73.1/24
+    #nohook wpa_supplicant # Optional: if you want to manage wlan0 entirely via hostapd and not system networking.
+                           # For a dedicated hotspot, this is often a good idea.
+                           # If you use wlan0 for client mode sometimes, don't add this.
+    ```
+
+3.  Save and exit.
+
+4.  Restart `dhcpcd` to apply the changes (or reboot the Pi):
+    ```bash
+    sudo systemctl restart dhcpcd
+    ```
+    Verify with `ip addr show wlan0` that it has the IP `192.168.73.1`.
+
+**NAT and IP Forwarding (`scripts/setup_hotspot_nat.sh`):**
+
+This script enables the Raspberry Pi to act as a router, forwarding traffic from the Wi-Fi hotspot clients (`wlan0`) to your main internet connection (assumed to be `eth0`).
+
+1.  **Review Internet Interface:**
+    The script defaults to using `eth0` as the internet-connected interface (`ETH_IF="eth0"`). If your Raspberry Pi gets its internet connection from a different interface (e.g., `usb0`, or another Wi-Fi adapter like `wlan1`), **you must edit `scripts/setup_hotspot_nat.sh` and change the `ETH_IF` variable** to match your setup.
+
+2.  **Make the Script Executable:**
+    Navigate to the directory where you cloned the repository.
+    ```bash
+    chmod +x scripts/setup_hotspot_nat.sh
+    ```
+
+3.  **Run the Script:**
+    Execute the script with superuser privileges:
+    ```bash
+    sudo ./scripts/setup_hotspot_nat.sh
+    ```
+    This will enable IP forwarding and set up the necessary `iptables` rules. The script includes rules to allow DHCP and DNS traffic to the Pi itself on `wlan0`, which are needed for Pi-hole/dnsmasq to function for hotspot clients.
+
+4.  **Make Firewall Rules Persistent:**
+    The `iptables` rules set by the script are temporary and will be lost on reboot. To make them persistent:
+    *   Install `iptables-persistent`:
+        ```bash
+        sudo apt-get update && sudo apt-get install -y iptables-persistent
+        ```
+    *   During the installation, you will be asked if you want to save current IPv4 and IPv6 rules. Answer **Yes** for IPv4. You can answer No for IPv6 if you are not using it.
+    *   If you modify the firewall rules later (e.g., by re-running the `setup_hotspot_nat.sh` script or making manual changes), you must save them again:
+        ```bash
+        sudo netfilter-persistent save
+        # Alternatively, reconfigure the package:
+        # sudo dpkg-reconfigure iptables-persistent
+        ```
+
+## IV. Starting and Testing the Hotspot
+
+1.  **Reboot (Recommended):**
+    After all configurations, it's often best to reboot the Raspberry Pi to ensure all services start in the correct order with the new settings.
+    ```bash
+    sudo reboot
+    ```
+
+2.  **If you didn't reboot, start `hostapd` manually (first time):**
+    ```bash
+    sudo systemctl start hostapd
+    ```
+
+3.  **Check Service Status:**
+    After rebooting or starting, check the status of the services:
+    ```bash
+    sudo systemctl status hostapd
+    sudo systemctl status pihole-FTL.service # or dnsmasq if you inspect it directly
+    ip addr show wlan0
+    ```
+    Look for `hostapd` being active and `wlan0` having the IP `192.168.73.1`.
+
+4.  **Test the Hotspot:**
+    *   On another device (laptop, phone), search for Wi-Fi networks.
+    *   You should see the network named `rpi` (or whatever you set as `ssid`).
+    *   Connect to it using the password you set.
+    *   Your device should receive an IP address in the `192.168.73.10` - `192.168.73.200` range.
+    *   Try browsing the internet. Traffic should be routed through the Raspberry Pi, and DNS queries should be handled by Pi-hole. You can check Pi-hole's query log to confirm.
+
+## Troubleshooting Tips:
+
+*   **`rfkill`**: If `wlan0` is blocked, use `sudo rfkill unblock wifi` or `sudo rfkill unblock all`.
+*   **`hostapd` fails to start**:
+    *   Check `sudo systemctl status hostapd` and `journalctl -u hostapd` for error messages.
+    *   Ensure `wlan0` is not already in use or configured in client mode by other networking services (e.g. NetworkManager or wpa_supplicant if not properly configured for AP mode). The `nohook wpa_supplicant` line in `dhcpcd.conf` for `wlan0` can help prevent conflicts.
+    *   Verify the `country_code` in `hostapd.conf` is valid.
+*   **No IP address on client devices**:
+    *   Ensure `pihole-FTL.service` (dnsmasq) is running and configured correctly for `wlan0`. Check `/var/log/pihole-FTL.log` or `/var/log/daemon.log` / `/var/log/syslog` for dnsmasq errors.
+    *   Verify the `iptables` rules for DHCP (port 67) are present (`sudo iptables -L INPUT -v -n --line-numbers`).
+*   **No internet on client devices**:
+    *   Double-check the `ETH_IF` variable in `setup_hotspot_nat.sh` matches your actual internet-providing interface.
+    *   Ensure IP forwarding is enabled: `cat /proc/sys/net/ipv4/ip_forward` (should be `1`).
+    *   Verify the `iptables` NAT and FORWARD rules: `sudo iptables -t nat -L -v -n --line-numbers` and `sudo iptables -L FORWARD -v -n --line-numbers`.
+    *   Check DNS settings on the client – it should be `192.168.73.1`.
+
+This completes the setup for your Chernarus_Beacon Wi-Fi hotspot!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,184 @@
-# surviving-chernarus
+# Operación: The Perimeter - Raspberry Pi Network Security Setup
 
-Este proyecto tiene como objetivo desarrollar un centro de control integral en una Raspberry Pi 5. Integrará Inteligencia Artificial, capacidades avanzadas de router Wi-Fi (hotspot), servicios web autoalojados, una base de datos robusta, seguridad perimetral y del sistema, y automatización de tareas. Los pilares del proyecto son la resiliencia, la portabilidad, la autosuficiencia y un alto grado de personalización y control.
+Welcome to "Operación: The Perimeter," a project to establish a secure and monitored Wi-Fi hotspot environment using a Raspberry Pi 5. This setup includes a Wi-Fi access point, DHCP services integrated with Pi-hole, a transparent caching and filtering Squid proxy, and a captive portal for user guidance on CA certificate installation.
+
+This README provides a consolidated overview and deployment plan. Detailed setup guides for each component are available in their respective directories.
+
+## Project Components and Thematic Names:
+
+*   **Wi-Fi Hotspot (`Chernarus_Beacon`):** Provides wireless access. (`wlan0` interface, network `192.168.73.0/24`)
+*   **DHCP & DNS (via `StarySobor_RadioPost` - Pi-hole):** Manages IP assignments and DNS for the hotspot. (Pi-hole instance assumed to be running on the RPi at `192.168.73.1`)
+*   **Squid Proxy (`Berezino_Checkpoint`):** Transparently proxies HTTP/HTTPS traffic for caching and potential filtering. (Docker container)
+*   **Captive Portal (`Chernarus_Entrypoint`):** Guides users to install the necessary CA certificate for HTTPS inspection. (Docker container, Nginx)
+
+## I. Generated Files and Key Directories
+
+**Hotspot Configuration (`Chernarus_Beacon`):**
+*   `hotspot_config/hostapd.conf` (Wi-Fi AP configuration)
+*   `hotspot_config/pihole_custom_dnsmasq.conf` (DHCP configuration for Pi-hole/dnsmasq)
+*   `scripts/setup_hotspot_nat.sh` (NAT and forwarding script for basic internet access)
+*   `GUIDANCE_AND_EXPLANATIONS.md` (Detailed setup guide for the hotspot component)
+
+**Squid Proxy (`Berezino_Checkpoint`):**
+*   `squid_Berezino_Checkpoint/docker-compose.yml` (Docker Compose for Squid)
+*   `squid_Berezino_Checkpoint/squid.conf` (Squid proxy configuration)
+*   `squid_Berezino_Checkpoint/certs/.gitkeep` (Placeholder for SSL CA certificate - **user must add `myCA.pem` here**)
+*   `scripts/redirect_to_squid.sh` (iptables script to redirect traffic to Squid)
+*   `squid_Berezino_Checkpoint/README_SQUID.md` (Detailed setup guide for the Squid proxy component)
+
+**Captive Portal (`Chernarus_Entrypoint`):**
+*   `captive_portal_Chernarus_Entrypoint/docker-compose.yml` (Docker Compose for Nginx portal)
+*   `captive_portal_Chernarus_Entrypoint/html/index.html` (Portal page for CA certificate download)
+*   `captive_portal_Chernarus_Entrypoint/html/.gitkeep` (Ensures `html` directory for `index.html` and CA cert - **user must add CA cert (e.g., `myCA.pem` or `.crt`) here for download**)
+*   `scripts/setup_captive_portal_redirect.sh` (iptables script to redirect users to portal)
+*   `captive_portal_Chernarus_Entrypoint/README_PORTAL.md` (Detailed setup guide for the captive portal component)
+
+**Repository Structure Overview:**
+```
+surviving-chernarus/
+├── hotspot_config/
+│   ├── hostapd.conf
+│   └── pihole_custom_dnsmasq.conf
+├── squid_Berezino_Checkpoint/
+│   ├── certs/
+│   │   └── .gitkeep
+│   ├── docker-compose.yml
+│   ├── README_SQUID.md
+│   └── squid.conf
+├── captive_portal_Chernarus_Entrypoint/
+│   ├── docker-compose.yml
+│   ├── html/
+│   │   ├── .gitkeep
+│   │   └── index.html
+│   └── README_PORTAL.md
+├── scripts/
+│   ├── redirect_to_squid.sh
+│   ├── setup_captive_portal_redirect.sh
+│   └── setup_hotspot_nat.sh
+├── GUIDANCE_AND_EXPLANATIONS.md
+└── README.md  # This file
+```
+
+## II. Deployment and Execution Summary
+
+**Refer to the detailed README files within each component's directory for in-depth explanations and troubleshooting.**
+
+**Phase 1: Prepare the Raspberry Pi OS & Network**
+1.  **Static IP for `eth0` (Internet Interface):** Ensure your Raspberry Pi has a predictable static IP address on its main Ethernet interface (e.g., `eth0`) if it doesn't already. This is good practice for a server.
+2.  **Static IP for `wlan0` (Hotspot Interface):** Configure `wlan0` with the static IP `192.168.73.1` (netmask `255.255.255.0`). This can be done via `/etc/dhcpcd.conf` or network management tools. The `GUIDANCE_AND_EXPLANATIONS.md` provides an example.
+3.  **Install Required OS Packages:**
+    ```bash
+    sudo apt-get update
+    sudo apt-get install -y hostapd iptables-persistent docker.io docker-compose
+    ```
+    (Note: `docker.io` and `docker-compose` package names might vary. Use official Docker installation guides for Raspberry Pi OS if needed.)
+4.  **Enable Docker Service:**
+    ```bash
+    sudo systemctl enable docker
+    sudo systemctl start docker
+    ```
+5.  **USB Drive for Persistent Data (Recommended):**
+    *   Ensure your USB drive is mounted (e.g., at `/mnt/usbdata`).
+    *   Create subdirectories for Squid data:
+        ```bash
+        sudo mkdir -p /mnt/usbdata/Berezino_Checkpoint/logs
+        sudo mkdir -p /mnt/usbdata/Berezino_Checkpoint/cache
+        # Adjust permissions if necessary. Example for Squid user (proxy, UID 31):
+        # sudo chown -R 31:31 /mnt/usbdata/Berezino_Checkpoint
+        # Or use chmod 777 initially for testing if permissions issues arise.
+        ```
+
+**Phase 2: Deploy Configurations from This Repository**
+1.  **Clone Repository:** (Example path `/opt/surviving-chernarus`)
+    ```bash
+    # git clone https://github.com/yourusername/surviving-chernarus.git /opt/surviving-chernarus
+    # cd /opt/surviving-chernarus
+    ```
+2.  **Review and Customize (CRITICAL):**
+    *   **`hotspot_config/hostapd.conf`:** Set a strong `wpa_passphrase`. Verify `country_code`.
+    *   **SSL CA Certificate:**
+        1.  Generate your CA certificate (e.g., `myCA.pem` containing both key and cert). Refer to `squid_Berezino_Checkpoint/README_SQUID.md` for guidance.
+        2.  Place this `myCA.pem` into `squid_Berezino_Checkpoint/certs/`.
+        3.  Place a copy of the public certificate part (e.g., `myCA.pem` or `myCA.crt`) into `captive_portal_Chernarus_Entrypoint/html/` for download by clients.
+        4.  Ensure the download link in `captive_portal_Chernarus_Entrypoint/html/index.html` (e.g., `href="/myCA.pem"`) correctly points to the certificate file you placed in the `html` directory.
+    *   Review all scripts in `scripts/` directory to ensure interface names (`eth0`, `wlan0`) match your system.
+
+**Phase 3: Setup Hotspot (`Chernarus_Beacon`)**
+(See `GUIDANCE_AND_EXPLANATIONS.md` for details)
+1.  **`hostapd`:**
+    ```bash
+    sudo cp hotspot_config/hostapd.conf /etc/hostapd/hostapd.conf
+    # Edit /etc/default/hostapd and set DAEMON_CONF="/etc/hostapd/hostapd.conf"
+    sudo sed -i 's|^#DAEMON_CONF=.*|DAEMON_CONF="/etc/hostapd/hostapd.conf"|' /etc/default/hostapd
+    sudo systemctl unmask hostapd
+    sudo systemctl enable hostapd
+    sudo systemctl start hostapd
+    ```
+2.  **DHCP (via Pi-hole/dnsmasq):**
+    ```bash
+    sudo cp hotspot_config/pihole_custom_dnsmasq.conf /etc/dnsmasq.d/02-chernarus-hotspot-dhcp.conf # Example name
+    sudo pihole restartdns # or sudo systemctl restart pihole-FTL.service
+    ```
+    Verify in Pi-hole admin DHCP settings.
+3.  **NAT & Forwarding (Basic Internet):**
+    ```bash
+    chmod +x scripts/setup_hotspot_nat.sh
+    sudo ./scripts/setup_hotspot_nat.sh
+    sudo netfilter-persistent save # Persist iptables rules
+    ```
+
+**Phase 4: Setup Captive Portal (`Chernarus_Entrypoint`)**
+(See `captive_portal_Chernarus_Entrypoint/README_PORTAL.md` for details)
+1.  **Docker Service:** Navigate to `captive_portal_Chernarus_Entrypoint/`.
+    ```bash
+    sudo docker-compose up -d
+    ```
+    Check logs: `sudo docker-compose logs -f chernarus_entrypoint`
+2.  **`iptables` Redirection to Portal:**
+    ```bash
+    chmod +x scripts/setup_captive_portal_redirect.sh
+    sudo ./scripts/setup_captive_portal_redirect.sh
+    # This script attempts to insert rules at the top. Review rule order if issues.
+    sudo netfilter-persistent save
+    ```
+
+**Phase 5: Setup Squid Proxy (`Berezino_Checkpoint`)**
+(See `squid_Berezino_Checkpoint/README_SQUID.md` for details)
+1.  **Docker Service:** Navigate to `squid_Berezino_Checkpoint/`.
+    ```bash
+    sudo docker-compose up -d
+    ```
+    Check logs: `sudo docker-compose logs -f berezino_checkpoint`
+2.  **`iptables` Redirection to Squid:**
+    ```bash
+    chmod +x scripts/redirect_to_squid.sh
+    sudo ./scripts/redirect_to_squid.sh
+    # This script adds rules after the portal's expected rules.
+    sudo netfilter-persistent save
+    ```
+
+**Order of `iptables` Script Execution for NAT Table (`PREROUTING` chain for `wlan0`):**
+The system relies on `iptables` rules being applied in a specific sequence. If you need to reset or reapply:
+1.  `scripts/setup_hotspot_nat.sh` (Basic NAT/Forwarding - less specific, broader rules)
+2.  `scripts/setup_captive_portal_redirect.sh` (Redirects HTTP to portal - more specific, should be early)
+3.  `scripts/redirect_to_squid.sh` (Redirects HTTP/HTTPS to Squid - processes what's left or bypasses portal for HTTPS)
+Always save rules with `sudo netfilter-persistent save` after changes.
+
+**Phase 6: Client Device Configuration**
+1.  Connect a client device to the `rpi` Wi-Fi SSID.
+2.  The client should get an IP from the `192.168.73.10-200` range.
+3.  Open a web browser and try to visit an **HTTP** website (e.g., `http://neverssl.com`). You should be redirected to the `Chernarus_Entrypoint` portal page.
+4.  Download the CA certificate from the portal and install it on the client device following the instructions on the portal page.
+5.  Test browsing **HTTPS** websites. Traffic should now be proxied by Squid, and browser warnings should be gone if the CA is trusted.
+
+## III. Assumptions and Clarifications
+
+*   **`project_rules.md` and `user_rules.md`:** These files were not accessible. Configurations are based on standard practices.
+*   **Pi-hole (`StarySobor_RadioPost`) Setup:** Assumes Pi-hole is already installed, functional, and accessible at `192.168.73.1` for DNS by hotspot clients.
+*   **Internet Connectivity:** Assumes `eth0` (or your primary internet interface) is configured for internet access.
+*   **Firewall Base State:** Assumes a relatively permissive default `iptables` policy. The provided scripts add necessary rules for the project's functionality.
+*   **Security of CA Key:** The CA private key is highly sensitive. Protect it. The `.pem` file in `squid_Berezino_Checkpoint/certs/` should have restricted permissions on the host.
+*   **Thematic Hostnames in DNS:** For hostnames like `berezino-checkpoint` to be resolvable by clients, add them to Pi-hole's "Local DNS Records" pointing to `192.168.73.1`.
+*   **`iptables` vs. `nftables`:** This solution uses `iptables`. If your system uses `nftables` as the default backend, script adjustments will be needed.
+
+This concludes the setup for "Operación: The Perimeter". Review all component READMEs and configurations carefully before and during deployment. Remember to test each phase incrementally. Good luck, survivor!

--- a/captive_portal_Chernarus_Entrypoint/README_PORTAL.md
+++ b/captive_portal_Chernarus_Entrypoint/README_PORTAL.md
@@ -1,0 +1,126 @@
+# Chernarus_Entrypoint (Captive Portal) Setup Guide
+
+This guide provides instructions for setting up the `Chernarus_Entrypoint` captive portal using Docker on your Raspberry Pi 5. The portal's primary purpose is to guide users connecting to the `rpi` Wi-Fi hotspot (`192.168.73.0/24`) to download and install the necessary CA certificate for the `Berezino_Checkpoint` Squid proxy.
+
+## Generated Configuration Files:
+
+1.  **`captive_portal_Chernarus_Entrypoint/docker-compose.yml`**: Docker Compose configuration to run Nginx for serving the portal page.
+2.  **`captive_portal_Chernarus_Entrypoint/html/index.html`**: The static HTML page for the portal.
+3.  **`captive_portal_Chernarus_Entrypoint/html/.gitkeep`**: Ensures the `html` directory is tracked.
+4.  **`scripts/setup_captive_portal_redirect.sh`**: Script to set up `iptables` rules for redirecting new hotspot clients to the portal.
+
+## I. Prerequisites
+
+*   Docker and Docker Compose are installed on your Raspberry Pi 5.
+*   The Wi-Fi hotspot (`rpi` SSID on `wlan0`, network `192.168.73.0/24`) is operational.
+*   The `Berezino_Checkpoint` Squid proxy is set up (though not necessarily running yet for initial portal setup).
+*   You have the CA certificate file (e.g., `myCA.pem` or `myCA.crt`) that you generated for the Squid proxy (`Berezino_Checkpoint`).
+
+## II. Prepare Portal Content
+
+1.  **Copy CA Certificate to Portal's HTML Directory:**
+    Place the CA certificate file (e.g., `myCA.pem` or `myCA.crt` – the one clients need to install, usually the `.crt` or the `.pem` if it's just the public cert) into the `captive_portal_Chernarus_Entrypoint/html/` directory. This makes it downloadable via the Nginx server.
+    ```bash
+    # Example: If your CA certificate is myCA.pem from the Squid setup
+    cp path/to/squid_Berezino_Checkpoint/certs/myCA.pem path/to/captive_portal_Chernarus_Entrypoint/html/myCA.pem
+    # Or if you have a .crt version for distribution:
+    # cp path/to/myCA.crt path/to/captive_portal_Chernarus_Entrypoint/html/myCA.crt
+    ```
+
+2.  **Update Download Link in `index.html` (If Necessary):**
+    Open `captive_portal_Chernarus_Entrypoint/html/index.html`.
+    The current download link is:
+    `<a href="/myCA.pem" download="Chernarus_Root_CA.pem" class="button">Download Chernarus_Root_CA.pem</a>`
+    *   If your CA certificate file is named differently (e.g., `myCA.crt`), change `/myCA.pem` to `/myCA.crt` (or whatever your filename is).
+    *   The `download="Chernarus_Root_CA.pem"` attribute suggests a user-friendly name for the file when saved by the user; you can keep this or change it.
+
+## III. Docker Compose Setup (Nginx Portal Server)
+
+The `captive_portal_Chernarus_Entrypoint/docker-compose.yml` file defines the Nginx service.
+
+1.  **Navigate to the Directory:**
+    Open a terminal on your Raspberry Pi and change to the directory containing this `docker-compose.yml` file:
+    ```bash
+    cd path/to/your/cloned/repository/captive_portal_Chernarus_Entrypoint/
+    ```
+2.  **Start Nginx Service:**
+    ```bash
+    docker-compose up -d
+    ```
+    This will pull the `nginx:alpine` image and start the `Chernarus_Entrypoint` container. The portal will be accessible on the Raspberry Pi's IP at port 8080 (e.g., `http://192.168.73.1:8080`).
+
+3.  **Check Container Status:**
+    ```bash
+    docker ps
+    docker logs Chernarus_Entrypoint
+    ```
+    Ensure Nginx is running without errors. You should be able to access `http://<RPi_IP>:8080` (e.g., `http://192.168.73.1:8080`) from a device on the RPi's network (or from the RPi itself).
+
+## IV. `iptables` Traffic Redirection
+
+The `scripts/setup_captive_portal_redirect.sh` script configures `iptables` to redirect new users on the hotspot to the captive portal page.
+
+1.  **Review the Script:**
+    Familiarize yourself with `scripts/setup_captive_portal_redirect.sh`. It's designed to redirect HTTP (port 80) traffic from `wlan0` clients to the portal at `192.168.73.1:8080`.
+
+2.  **Make it Executable:**
+    ```bash
+    chmod +x path/to/your/cloned/repository/scripts/setup_captive_portal_redirect.sh
+    ```
+
+3.  **Run the Script:**
+    Execute it with `sudo` privileges:
+    ```bash
+    sudo path/to/your/cloned/repository/scripts/setup_captive_portal_redirect.sh
+    ```
+
+**Redirection Strategy and `iptables` Rule Order:**
+
+*   **Simplified Approach:** The script inserts an `iptables` rule at the *top* of the `PREROUTING` chain in the `nat` table. This rule redirects all HTTP (port 80) requests from hotspot clients (`wlan0`) to the portal at `http://192.168.73.1:8080`.
+*   **How it Works:**
+    1.  A new user connects to the `rpi` Wi-Fi.
+    2.  Their first HTTP request (e.g., to `http://example.com`) is caught by this rule and redirected.
+    3.  They see the `index.html` page, download, and install the CA certificate.
+    4.  After CA installation, HTTPS sites should work via the Squid proxy.
+*   **Limitation:** HTTP sites will *continue* to be redirected to the portal. This might be acceptable if most critical browsing is HTTPS.
+*   **Order of Execution for `iptables` Scripts:** For the whole system to work as intended, scripts affecting `iptables` should be run in a specific order:
+    1.  `scripts/setup_hotspot_nat.sh` (Basic NAT and forwarding for internet access)
+    2.  `scripts/setup_captive_portal_redirect.sh` (This portal redirection script - for HTTP)
+    3.  `scripts/redirect_to_squid.sh` (Redirects HTTP and HTTPS to Squid)
+    The portal script attempts to insert its rule first, ensuring it's processed before Squid's HTTP redirection.
+
+*   **Alternative (No Automatic Redirection):** If you prefer not to redirect all HTTP traffic:
+    *   Do not run `scripts/setup_captive_portal_redirect.sh`.
+    *   Modify Nginx in `captive_portal_Chernarus_Entrypoint/docker-compose.yml` to listen directly on port 80 (e.g., `ports: - "80:80"`), assuming no other service on the Pi uses port 80.
+    *   Instruct users to manually visit a specific address like `http://192.168.73.1` or a friendly DNS name (e.g., `http://welcome.chernarus.local`) that you configure in Pi-hole to point to `192.168.73.1`.
+
+4.  **Persistence:**
+    The `iptables` rules are volatile. After confirming functionality:
+    *   Install `iptables-persistent` if not already done: `sudo apt-get update && sudo apt-get install -y iptables-persistent`
+    *   Save the rules: `sudo netfilter-persistent save`
+    *   If you re-run any of the `iptables` setup scripts or manually change rules, remember to save them again.
+
+## V. Testing
+
+1.  Ensure `Chernarus_Entrypoint` (Nginx) and `Berezino_Checkpoint` (Squid) Docker containers are running.
+2.  Ensure `iptables` rules from all relevant scripts (`setup_hotspot_nat.sh`, `setup_captive_portal_redirect.sh`, `redirect_to_squid.sh`) have been applied in the correct order.
+3.  Connect a **new client device** to the `rpi` Wi-Fi hotspot.
+4.  Open a web browser on the client and attempt to visit an **HTTP** website (e.g., `http://neverssl.com` or `http://example.com`). You should be redirected to the `Chernarus_Entrypoint` portal page (`http://192.168.73.1:8080`).
+5.  From the portal page, download the `Chernarus_Root_CA.pem` (or `.crt`) file.
+6.  Install and trust the CA certificate on the client device as per the instructions on the portal page.
+7.  Attempt to visit an **HTTPS** website (e.g., `https://google.com`). It should now load correctly, with the certificate being issued by your "BerezinoCheckpointCA".
+8.  Verify that HTTP sites still redirect to the portal (this is the behavior of the simplified redirection).
+
+## VI. Stopping the Portal
+
+To stop the Nginx portal service:
+```bash
+cd path/to/your/cloned/repository/captive_portal_Chernarus_Entrypoint/
+docker-compose down
+```
+This does not remove the `iptables` redirection rules. If you want to disable portal redirection, you'll need to manually remove the specific `iptables` rule or flush the `PREROUTING` chain (carefully, if other rules exist) and re-apply only the Squid redirection.
+Example to delete the portal rule (if it's the first one in PREROUTING nat):
+`sudo iptables -t nat -D PREROUTING 1`
+Then re-save with `sudo netfilter-persistent save`.
+
+This completes the setup for the `Chernarus_Entrypoint` captive portal.

--- a/captive_portal_Chernarus_Entrypoint/docker-compose.yml
+++ b/captive_portal_Chernarus_Entrypoint/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  chernarus_entrypoint:
+    image: nginx:alpine # Lightweight and supports arm64
+    container_name: Chernarus_Entrypoint
+    hostname: chernarus-entrypoint # Thematic hostname
+    restart: unless-stopped
+    ports:
+      - "8080:80" # Expose Nginx on host port 8080, internally listens on 80
+    volumes:
+      - ./html:/usr/share/nginx/html:ro # Mount static HTML content
+      # Optional: Mount custom nginx config if needed later
+      # - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    # networks:
+    #   # If using a custom network
+    #   proxy_network:
+
+# networks:
+#   proxy_network:
+#     driver: bridge

--- a/captive_portal_Chernarus_Entrypoint/html/.gitkeep
+++ b/captive_portal_Chernarus_Entrypoint/html/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the 'html' directory is tracked by Git.
+# Place your index.html and CA certificate file (e.g., myCA.pem) here.

--- a/captive_portal_Chernarus_Entrypoint/html/index.html
+++ b/captive_portal_Chernarus_Entrypoint/html/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chernarus Network Access</title>
+    <style>
+        body { font-family: 'Courier New', Courier, monospace; background-color: #282a36; color: #f8f8f2; line-height: 1.6; padding: 20px; }
+        .container { max-width: 800px; margin: auto; background-color: #44475a; padding: 20px; border-radius: 8px; border: 1px solid #6272a4; }
+        h1 { color: #50fa7b; border-bottom: 1px solid #50fa7b; padding-bottom: 10px; }
+        p { margin-bottom: 15px; }
+        a { color: #8be9fd; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        .warning { background-color: #ffb86c; color: #282a36; padding: 15px; border-radius: 4px; border-left: 5px solid #ff5555; }
+        .button {
+            display: inline-block;
+            background-color: #50fa7b;
+            color: #282a36;
+            padding: 10px 20px;
+            text-decoration: none;
+            border-radius: 5px;
+            font-weight: bold;
+            border: none;
+            cursor: pointer;
+        }
+        .button:hover { background-color: #42e068; }
+        ul { list-style-type: square; padding-left: 20px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Welcome to the Chernarus Secure Network</h1>
+        <p>To ensure secure and filtered internet access via <strong>Berezino_Checkpoint</strong>, you need to install our network's root CA certificate on your device.</p>
+
+        <div class="warning">
+            <p><strong>Important:</strong> Without this certificate, you will experience security warnings and may not be able to access many websites (especially HTTPS sites).</p>
+        </div>
+
+        <h2>Certificate Installation Guide</h2>
+        <p>Please follow these steps:</p>
+        <ol>
+            <li>
+                <strong>Download the CA Certificate:</strong>
+                <!-- User must place their myCA.pem (or .crt) file in the html directory and update this link -->
+                <p><a href="/myCA.pem" download="Chernarus_Root_CA.pem" class="button">Download Chernarus_Root_CA.pem</a></p>
+                <p>(If the download doesn't start, ensure `myCA.pem` is present in the `captive_portal_Chernarus_Entrypoint/html/` directory on the server and this link points to the correct filename.)</p>
+            </li>
+            <li>
+                <strong>Install the Certificate:</strong> The installation process varies by operating system:
+                <ul>
+                    <li><strong>Windows:</strong> Double-click the downloaded file, click "Install Certificate...", choose "Local Machine", click "Next", select "Place all certificates in the following store", click "Browse...", choose "Trusted Root Certification Authorities", click "OK", "Next", and "Finish".</li>
+                    <li><strong>macOS:</strong> Double-click the downloaded file. Keychain Access will open. Find the certificate (usually in 'login' keychain), double-click it, expand "Trust", and set "When using this certificate:" to "Always Trust".</li>
+                    <li><strong>iOS (iPhone/iPad):</strong> Download the certificate. Go to Settings > General > Profile (or VPN & Device Management). Tap on the downloaded profile and follow prompts to install. Then, go to Settings > General > About > Certificate Trust Settings and enable full trust for the root certificate.</li>
+                    <li><strong>Android:</strong> Download the certificate. Go to Settings > Security > Encryption & credentials (or Advanced > Encryption & credentials) > Install a certificate (or Install from storage). Choose "CA certificate" or "Wi-Fi certificate". You may be prompted to set a device PIN or password if you haven't already.</li>
+                    <li><strong>Linux:</strong> The process varies by distribution. Generally, you need to copy the `.pem` or `.crt` file to `/usr/local/share/ca-certificates/` and then run `sudo update-ca-certificates`.</li>
+                </ul>
+            </li>
+            <li><strong>Reconnect to Wi-Fi:</strong> After installing the certificate, you might need to disconnect and reconnect to the `rpi` Wi-Fi network.</li>
+        </ol>
+        <p>Once the certificate is installed and trusted, your internet traffic will be securely processed by `Berezino_Checkpoint`.</p>
+        <hr>
+        <p><small>Project: Surviving Chernarus - Report any issues to the administrator.</small></p>
+    </div>
+</body>
+</html>

--- a/hotspot_config/hostapd.conf
+++ b/hotspot_config/hostapd.conf
@@ -1,0 +1,25 @@
+interface=wlan0
+driver=nl80211
+ssid=rpi
+hw_mode=g
+channel=7
+wmm_enabled=0
+macaddr_acl=0
+auth_algs=1
+ignore_broadcast_ssid=0
+wpa=2
+# ======================================================================
+# IMPORTANT: YOU MUST CHANGE THIS PASSWORD TO A STRONG, UNIQUE VALUE!
+# ======================================================================
+wpa_passphrase=YourStrongPasswordHere
+wpa_key_mgmt=WPA-PSK
+wpa_pairwise=TKIP
+rsn_pairwise=CCMP
+# ======================================================================
+# Country code (e.g., US for United States, GB for United Kingdom)
+# User should verify and set this according to their location to ensure
+# compliance with local wireless regulations.
+# ======================================================================
+country_code=US
+ieee80211n=1
+ht_capab=[HT40][SHORT-GI-20][DSSS_CCK-40]

--- a/hotspot_config/pihole_custom_dnsmasq.conf
+++ b/hotspot_config/pihole_custom_dnsmasq.conf
@@ -1,0 +1,29 @@
+# Custom dnsmasq configuration for Chernarus_Beacon (wlan0 Hotspot)
+# This file should be placed in /etc/dnsmasq.d/ on the Pi-hole host
+# (e.g., as 02-custom-dhcp.conf or similar) and FTL restarted.
+
+# Enable DHCP for the wlan0 interface
+interface=wlan0
+
+# Set the DHCP address range and lease time for wlan0
+# Ensure this range does not overlap with other networks.
+# The gateway IP (192.168.73.1) is excluded from the range.
+dhcp-range=interface:wlan0,192.168.73.10,192.168.73.200,255.255.255.0,12h
+
+# Set the gateway option for wlan0 clients
+dhcp-option=interface:wlan0,3,192.168.73.1
+
+# Set the DNS server option for wlan0 clients (Pi-hole itself)
+dhcp-option=interface:wlan0,6,192.168.73.1
+
+# If your Pi-hole is on a different IP accessible to the 192.168.73.0/24 network,
+# replace 192.168.73.1 in the dhcp-option 6 above with Pi-hole's actual IP.
+# However, for simplicity, this configuration assumes Pi-hole and the hotspot
+# gateway are on the same RPi, and Pi-hole listens on 192.168.73.1 for DNS.
+
+# Domain for the hotspot
+domain=hotspot.chernarus
+local=/hotspot.chernarus/
+
+# Log DHCP transactions
+log-dhcp

--- a/scripts/redirect_to_squid.sh
+++ b/scripts/redirect_to_squid.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Script to redirect HTTP/HTTPS traffic from hotspot clients to Berezino_Checkpoint (Squid)
+
+# Variables
+WLAN_IF="wlan0"                 # Hotspot interface
+HOTSPOT_NET="192.168.73.0/24"   # Hotspot network
+SQUID_HTTP_PORT="3128"          # Squid's HTTP listening port (from squid.conf http_port)
+SQUID_HTTPS_PORT="3129"         # Squid's HTTPS listening port (from squid.conf https_port)
+RPI_WLAN_IP="192.168.73.1"      # RPi's IP on wlan0
+
+echo "Configuring iptables to redirect traffic from $WLAN_IF to Squid..."
+
+# === PREROUTING rules for traffic originating from hotspot clients ===
+
+# --- IMPORTANT: Traffic to the Raspberry Pi itself on wlan0 should NOT be redirected ---
+# This includes DNS (port 53 to Pi-hole/192.168.73.1), DHCP (port 67/68),
+# and potentially a captive portal hosted on the RPi (e.g. on port 80/443 on 192.168.73.1).
+# The DNAT rules below will use -d ! $RPI_WLAN_IP to avoid this loop for traffic destined
+# for the Pi itself. However, for true transparent proxying of traffic *through* the Pi,
+# this is tricky.
+# A common approach for transparent proxying is to apply redirection on the FORWARD chain for traffic
+# passing *through* the Pi, or on PREROUTING for traffic originated *from* the Pi (not the case here for clients).
+# For traffic from clients on wlan0 destined for the internet:
+# The DNAT rules on PREROUTING are appropriate.
+
+echo "Ensuring traffic directly to $RPI_WLAN_IP (e.g., DNS, Captive Portal) is NOT redirected..."
+# Allow traffic destined for the Pi-hole/RPi itself on wlan0 to bypass redirection
+# This is critical for DNS, DHCP, and the captive portal access.
+sudo iptables -t nat -A PREROUTING -i $WLAN_IF -d $RPI_WLAN_IP -p tcp -m multiport --dports 80,443 -j RETURN
+sudo iptables -t nat -A PREROUTING -i $WLAN_IF -d $RPI_WLAN_IP -p udp -m multiport --dports 53,67,68 -j RETURN
+
+
+echo "Redirecting HTTP traffic (port 80) from $HOTSPOT_NET (excluding to $RPI_WLAN_IP) to Squid port $SQUID_HTTP_PORT..."
+sudo iptables -t nat -A PREROUTING -i $WLAN_IF -s $HOTSPOT_NET -p tcp --dport 80 -d ! $RPI_WLAN_IP -j DNAT --to-destination 127.0.0.1:$SQUID_HTTP_PORT
+
+echo "Redirecting HTTPS traffic (port 443) from $HOTSPOT_NET (excluding to $RPI_WLAN_IP) to Squid port $SQUID_HTTPS_PORT..."
+sudo iptables -t nat -A PREROUTING -i $WLAN_IF -s $HOTSPOT_NET -p tcp --dport 443 -d ! $RPI_WLAN_IP -j DNAT --to-destination 127.0.0.1:$SQUID_HTTPS_PORT
+
+# === Allowing Squid Traffic ===
+# If the INPUT policy is DROP, you might need to explicitly allow traffic to Squid's ports.
+# However, Docker typically manages its own rules for exposing container ports.
+# The DOCKER chain in the nat table and FORWARD chain usually handle this.
+# For traffic originating from clients and DNATed to 127.0.0.1 (host),
+# the host's INPUT chain will see it.
+echo "Ensuring host can accept traffic to Squid ports (if INPUT policy is not ACCEPT)..."
+sudo iptables -A INPUT -i $WLAN_IF -p tcp --dport $SQUID_HTTP_PORT -s $HOTSPOT_NET -d 127.0.0.1 -j ACCEPT
+sudo iptables -A INPUT -i $WLAN_IF -p tcp --dport $SQUID_HTTPS_PORT -s $HOTSPOT_NET -d 127.0.0.1 -j ACCEPT
+
+# If Squid container is on a custom Docker network and not using host networking,
+# ensure FORWARD rules from wlan0 to that Docker bridge are in place.
+# The previous setup_hotspot_nat.sh should allow general forwarding from wlan0 to other interfaces
+# (like docker0 or other bridge). The -o $ETH_IF in that script might need adjustment if
+# Docker traffic doesn't exit via $ETH_IF directly (though usually it does after SNAT).
+
+echo ""
+echo "Redirection rules applied."
+echo "Verify with: sudo iptables -t nat -L PREROUTING -v -n"
+echo "And: sudo iptables -L INPUT -v -n"
+echo "Remember to make these rules persistent using iptables-persistent:"
+echo "sudo netfilter-persistent save"
+echo ""
+echo "IMPORTANT: Ensure your Raspberry Pi's firewall (INPUT/FORWARD chains) allows this redirected traffic"
+echo "and allows Squid to make outbound connections to the internet (usually via $ETH_IF or similar)."
+echo "The setup_hotspot_nat.sh script should generally cover outbound, but review if issues arise."

--- a/scripts/setup_captive_portal_redirect.sh
+++ b/scripts/setup_captive_portal_redirect.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Script for redirecting new hotspot users to the Chernarus_Entrypoint captive portal.
+# This script should ideally be run AFTER basic NAT/forwarding for the hotspot is set up
+# (e.g., by setup_hotspot_nat.sh) but BEFORE traffic is redirected to Squid
+# (e.g., by redirect_to_squid.sh).
+# The goal is to intercept HTTP traffic from new users and show them the portal page.
+
+# === Variables ===
+WLAN_IF="wlan0"                     # Interface for the hotspot
+RPI_WLAN_IP="192.168.73.1"          # IP address of the Raspberry Pi on the wlan0 network
+PORTAL_HOST_PORT="8080"             # Host port where Chernarus_Entrypoint (Nginx) is exposed
+SQUID_HTTP_PORT="3128"              # Squid's HTTP listening port
+
+# === Important: Rule Order and Strategy ===
+# This script uses a simple approach: redirect ALL HTTP (port 80) traffic from the hotspot
+# network to the captive portal.
+#
+# 1. New user connects, makes an HTTP request (e.g., to http://example.com).
+# 2. This PREROUTING rule catches it and redirects to the portal (192.168.73.1:8080).
+# 3. User sees instructions, downloads & installs CA.
+# 4. HTTPS sites then work via Squid (Berezino_Checkpoint).
+#
+# Limitation: HTTP sites will *continue* to redirect to the portal with this simple rule.
+# This might be acceptable if most critical browsing is HTTPS.
+#
+# For this to work correctly with the Squid proxy, this DNAT rule for the portal
+# MUST take precedence over the DNAT rule that sends port 80 traffic to Squid.
+# `iptables` rules are processed in order. One way to ensure precedence is to:
+#    a) Insert this rule at the top of the PREROUTING chain.
+#    b) Flush PREROUTING rules and apply them in the desired order:
+#       1. Portal Redirection (this script)
+#       2. Squid Redirection (from redirect_to_squid.sh)
+#
+# This script will insert the rule at the top of PREROUTING for -t nat.
+
+echo "Ensuring kernel parameters are set for forwarding..."
+# Should already be set by setup_hotspot_nat.sh, but good to ensure
+sudo sysctl -w net.ipv4.ip_forward=1
+# For transparent proxying and NAT, bridge netfilter might be needed if complex Docker networks involved
+# sudo sysctl -w net.bridge.bridge-nf-call-iptables=1 # Usually not needed for this direct DNAT approach
+
+echo "Flushing PREROUTING rules in 'nat' table for $WLAN_IF to ensure correct order (USE WITH CAUTION if other rules exist)..."
+# WARNING: This is a broad flush for the interface. If you have other critical PREROUTING rules
+# for wlan0 not managed by these scripts, this approach needs refinement.
+# A more targeted way would be to check if the rule exists and delete it before adding,
+# or use a dedicated chain. For simplicity in this project, we'll flush and re-add.
+# Consider a dedicated chain for project-specific rules if this becomes complex.
+# sudo iptables -t nat -F PREROUTING # Too broad. Let's be more specific or rely on order of execution.
+# For now, we will rely on the user running scripts in the correct order:
+# 1. setup_hotspot_nat.sh (general NAT/Forward)
+# 2. setup_captive_portal_redirect.sh (portal HTTP redirect - INSERTED FIRST)
+# 3. redirect_to_squid.sh (Squid HTTP/HTTPS redirect - added after portal rule)
+
+# === Allow Traffic TO the Portal Service on the RPi ===
+echo "Allowing INPUT traffic to the portal service on $RPI_WLAN_IP:$PORTAL_HOST_PORT..."
+# This ensures that traffic redirected to the RPi itself can reach the Nginx container.
+# Check if rule exists before adding
+sudo iptables -C INPUT -i $WLAN_IF -p tcp -d $RPI_WLAN_IP --dport $PORTAL_HOST_PORT -j ACCEPT 2>/dev/null || \
+    sudo iptables -A INPUT -i $WLAN_IF -p tcp -d $RPI_WLAN_IP --dport $PORTAL_HOST_PORT -j ACCEPT
+
+# === Captive Portal Redirection Rule ===
+# Redirect HTTP (port 80) traffic originating from the hotspot network,
+# and NOT destined for the RPi itself (to avoid loops if portal was on port 80),
+# to the Nginx portal on $RPI_WLAN_IP:$PORTAL_HOST_PORT.
+# The `-I PREROUTING 1` inserts the rule at the top (index 1).
+echo "Inserting captive portal HTTP redirection rule at the top of PREROUTING (nat table)..."
+sudo iptables -t nat -C PREROUTING -i $WLAN_IF -p tcp --dport 80 -j DNAT --to-destination $RPI_WLAN_IP:$PORTAL_HOST_PORT 2>/dev/null || \
+    sudo iptables -t nat -I PREROUTING 1 -i $WLAN_IF -p tcp --dport 80 -j DNAT --to-destination $RPI_WLAN_IP:$PORTAL_HOST_PORT
+
+# === Explanations and Warnings ===
+echo ""
+echo "--- Captive Portal Redirection Strategy ---"
+echo "The 'iptables' rule added by this script redirects all HTTP (port 80) requests from hotspot clients"
+echo "on interface '$WLAN_IF' to the Chernarus_Entrypoint portal page at $RPI_WLAN_IP:$PORTAL_HOST_PORT."
+echo ""
+echo "How it works (Simplified Approach):"
+echo "1. A new user connects. Any HTTP request they make (e.g., to http://example.com) gets redirected."
+echo "2. They see the index.html page with instructions to download and install the CA certificate."
+echo "3. Once they install the CA certificate, HTTPS sites should start working correctly via the Squid proxy (Berezino_Checkpoint)."
+echo ""
+echo "Limitation:"
+echo "With this simple rule, HTTP sites will *continue* to redirect to the portal even after CA installation."
+echo "Given most important web traffic is HTTPS, this might be an acceptable trade-off for simplicity."
+echo "Users wanting to access an HTTP site directly would be unable to without modifying these rules."
+echo ""
+echo "Alternative (Manual Access):"
+echo "Do not implement this automatic redirection. Instead, instruct users to manually visit http://$RPI_WLAN_IP:$PORTAL_HOST_PORT"
+echo "(or a custom domain like 'http://welcome.chernarus.local' if you set up a DNS entry in Pi-hole pointing"
+echo "to $RPI_WLAN_IP and change Nginx in docker-compose.yml for Chernarus_Entrypoint to listen on port 80, e.g., '80:80')."
+echo ""
+echo "Order of Rules is CRITICAL:"
+echo "This script attempts to insert the portal redirection rule at the beginning of the PREROUTING chain in the 'nat' table."
+echo "This is to ensure it's processed BEFORE any rule that might redirect HTTP traffic to Squid."
+echo "The intended order of script execution for iptables setup is:"
+echo "   1. Basic NAT/Forwarding (e.g., scripts/setup_hotspot_nat.sh)"
+echo "   2. Captive Portal HTTP Redirect (this script: scripts/setup_captive_portal_redirect.sh)"
+echo "   3. Squid Proxy Redirect (e.g., scripts/redirect_to_squid.sh)"
+echo ""
+echo "To make these rules persistent across reboots (after confirming functionality):"
+echo "   sudo apt-get install -y iptables-persistent"
+echo "   sudo netfilter-persistent save"
+echo "   (Or if already installed: sudo netfilter-persistent save)"
+echo ""
+echo "To view PREROUTING rules in nat table: sudo iptables -t nat -L PREROUTING -v -n --line-numbers"
+echo "To view INPUT rules: sudo iptables -L INPUT -v -n --line-numbers"
+echo "Captive portal redirection setup complete."

--- a/scripts/setup_hotspot_nat.sh
+++ b/scripts/setup_hotspot_nat.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Script to enable NAT and IP forwarding for the Chernarus_Beacon hotspot
+
+# Variables
+WLAN_IF="wlan0"       # Hotspot interface
+ETH_IF="eth0"         # Internet-connected interface (user may need to change this if using e.g. wlan1 for internet)
+HOTSPOT_NET="192.168.73.0/24"
+
+echo "Enabling IP forwarding..."
+sudo sysctl -w net.ipv4.ip_forward=1
+
+echo "Configuring iptables for NAT..."
+# It's generally safer not to flush all rules automatically.
+# The user can do this manually if a clean slate is needed.
+# echo "Flushing existing rules (optional, use with caution)..."
+# sudo iptables -F
+# sudo iptables -t nat -F
+
+echo "Allowing forwarding between $WLAN_IF and $ETH_IF..."
+# Allow traffic from hotspot to internet
+sudo iptables -A FORWARD -i $WLAN_IF -o $ETH_IF -j ACCEPT
+# Allow established and related connections back to the hotspot
+sudo iptables -A FORWARD -i $ETH_IF -o $WLAN_IF -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+echo "Applying NAT (Masquerade) rule for traffic from $HOTSPOT_NET via $ETH_IF..."
+# NAT rule: Masquerade traffic from hotspot network to $ETH_IF
+sudo iptables -t nat -A POSTROUTING -s $HOTSPOT_NET -o $ETH_IF -j MASQUERADE
+
+# ======================================================================
+# Optional INPUT rules for services on the Raspberry Pi itself (listening on wlan0)
+# Uncomment these if you are running services like SSH, DNS, DHCP directly on the Pi
+# and want them accessible from the hotspot clients.
+# Pi-hole (dnsmasq) will need DHCP and DNS.
+# These rules assume the RPi itself is 192.168.73.1.
+# ======================================================================
+echo "Adding INPUT rules for DHCP and DNS on $WLAN_IF..."
+sudo iptables -A INPUT -i $WLAN_IF -p udp --dport 67 -j ACCEPT  # DHCP Server (dnsmasq)
+sudo iptables -A INPUT -i $WLAN_IF -p udp --dport 53 -j ACCEPT  # DNS (dnsmasq/Pi-hole)
+sudo iptables -A INPUT -i $WLAN_IF -p tcp --dport 53 -j ACCEPT  # DNS (dnsmasq/Pi-hole)
+
+# Example: Allow SSH access to the RPi from the hotspot network
+# sudo iptables -A INPUT -i $WLAN_IF -p tcp --dport 22 -s $HOTSPOT_NET -j ACCEPT
+
+echo ""
+echo "NAT and forwarding configuration complete."
+echo "The internet-facing interface is assumed to be $ETH_IF. If it's different (e.g. usb0, wlan1), please edit this script."
+echo "To make these firewall rules persistent across reboots, you need to install 'iptables-persistent'."
+echo "Run: sudo apt-get update && sudo apt-get install -y iptables-persistent"
+echo "During the installation, you will be asked to save current IPv4 and IPv6 rules. Answer 'yes' for IPv4."
+echo "If you modify the rules later (e.g., by re-running this script with changes), update the saved rules with:"
+echo "sudo netfilter-persistent save"
+echo "or"
+echo "sudo dpkg-reconfigure iptables-persistent"

--- a/squid_Berezino_Checkpoint/README_SQUID.md
+++ b/squid_Berezino_Checkpoint/README_SQUID.md
@@ -1,0 +1,175 @@
+# Berezino_Checkpoint (Squid Proxy) Setup Guide
+
+This guide provides instructions for setting up the `Berezino_Checkpoint` Squid proxy using Docker on your Raspberry Pi 5. This proxy is intended to transparently intercept HTTP and HTTPS traffic from clients connected to the `rpi` Wi-Fi hotspot (`192.168.73.0/24`).
+
+## Generated Configuration Files:
+
+1.  **`squid_Berezino_Checkpoint/docker-compose.yml`**: Docker Compose configuration to run Squid.
+2.  **`squid_Berezino_Checkpoint/squid.conf`**: Custom configuration for Squid, enabling transparent proxying and SSL bumping.
+3.  **`squid_Berezino_Checkpoint/certs/`**: Directory to store your SSL CA certificate (you must create this).
+4.  **`scripts/redirect_to_squid.sh`**: Script to set up `iptables` rules for redirecting hotspot traffic to Squid.
+
+## I. Prerequisites
+
+*   Ensure Docker and Docker Compose are installed on your Raspberry Pi 5.
+*   Ensure the Wi-Fi hotspot (`rpi` SSID on `wlan0`, network `192.168.73.0/24`) is operational as per the previous `Chernarus_Beacon` setup.
+*   The NAT script (`scripts/setup_hotspot_nat.sh`) from the hotspot setup should already be in place and configured to allow general internet access for hotspot clients.
+*   Create the necessary directories on your Raspberry Pi for persistent Squid data, ensuring they have appropriate permissions for the user/group running Docker (or make them world-writable if unsure, though less secure for production):
+    ```bash
+    sudo mkdir -p /mnt/usbdata/Berezino_Checkpoint/cache
+    sudo mkdir -p /mnt/usbdata/Berezino_Checkpoint/logs
+    # Example permissions (adjust if your Docker user is different or for security):
+    # sudo chown -R <your_user>:<your_group> /mnt/usbdata/Berezino_Checkpoint
+    # Or, if Squid runs as 'proxy' user inside the container (common for ubuntu/squid image):
+    # The ubuntu/squid image runs as user 'proxy' (UID 31).
+    # You might need to set permissions for this UID or use a volume driver that handles it.
+    # For simplicity, you can initially try with open permissions and refine later:
+    sudo chmod -R 777 /mnt/usbdata/Berezino_Checkpoint/cache
+    sudo chmod -R 777 /mnt/usbdata/Berezino_Checkpoint/logs
+    ```
+
+## II. SSL Bumping CA Certificate Generation
+
+For Squid to intercept and inspect HTTPS traffic (`SSL Bumping`), you must generate your own Certificate Authority (CA) certificate and private key. This CA will be used by Squid to dynamically create certificates for the websites users visit.
+
+1.  **Generate CA Certificate and Key:**
+    Use a tool like OpenSSL. On your Raspberry Pi or another Linux machine, run:
+    ```bash
+    openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -keyout myCA.key -out myCA.crt -subj "/CN=BerezinoCheckpointCA/O=ChernarusNetwork/OU=ProxyServices"
+    ```
+    This creates `myCA.key` (private key) and `myCA.crt` (certificate).
+
+2.  **Combine into a PEM file:**
+    Squid's `squid.conf` is configured to use a single `.pem` file. Concatenate the key and certificate:
+    ```bash
+    cat myCA.crt myCA.key > myCA.pem
+    ```
+
+3.  **Place `myCA.pem` in the Certs Directory:**
+    Copy the generated `myCA.pem` file into the `squid_Berezino_Checkpoint/certs/` directory (which you cloned from the repository). This directory is mapped to `/etc/squid/certs/` inside the Docker container.
+    ```bash
+    # Assuming you are in the directory where you generated myCA.pem
+    cp myCA.pem path/to/your/cloned/repository/squid_Berezino_Checkpoint/certs/
+    ```
+
+4.  **Client Trust (Crucial):**
+    Each client device (laptops, phones) connecting to the `rpi` hotspot **MUST** install and trust your `myCA.crt` (the certificate part, not the key) in their system or browser trust store.
+    *   Without this, clients will see severe certificate errors for every HTTPS site.
+    *   The `Chernarus_Entrypoint` captive portal (to be set up later) will provide instructions and a download link for `myCA.crt` for users.
+
+## III. Squid Configuration (`squid.conf`)
+
+The provided `squid_Berezino_Checkpoint/squid.conf` is configured for:
+*   Transparent HTTP on port 3128.
+*   Transparent HTTPS (SSL Bumping) on port 3129, using the CA from `./certs/myCA.pem`.
+*   Access control allowing only clients from the `192.168.73.0/24` network.
+*   Caching and logging to the directories mapped in `docker-compose.yml`.
+*   Using `192.168.73.1` (Pi-hole) for DNS resolution by Squid.
+
+**Note on `sslcrtd_program` Path:**
+The path to `security_file_certgen` (the program Squid uses to generate certificates for SSL Bumping) is set to `/usr/lib/squid/security_file_certgen` in `squid.conf`. This is common for the `ubuntu/squid` Docker image. If Squid fails to start or SSL bumping doesn't work, check the Squid container logs (`docker logs Berezino_Checkpoint`) for errors related to this program. The path might differ in rare cases or future image updates.
+
+## IV. Docker Compose Setup
+
+The `squid_Berezino_Checkpoint/docker-compose.yml` file defines the Squid service.
+
+1.  **Review Volumes:** Ensure the volume paths for cache and logs (`/mnt/usbdata/Berezino_Checkpoint/...`) are correct and the directories exist with proper permissions on your Raspberry Pi (as per Step I).
+2.  **Navigate to the Directory:**
+    Open a terminal on your Raspberry Pi and change to the directory containing the `docker-compose.yml` file:
+    ```bash
+    cd path/to/your/cloned/repository/squid_Berezino_Checkpoint/
+    ```
+3.  **Start Squid Service:**
+    ```bash
+    docker-compose up -d
+    ```
+    This will pull the `ubuntu/squid` image (if not already present) and start the `Berezino_Checkpoint` container in detached mode.
+
+4.  **Check Container Status:**
+    ```bash
+    docker ps
+    docker logs Berezino_Checkpoint
+    ```
+    Look for any errors in the logs. If Squid starts correctly, it should indicate it's ready to accept connections on ports 3128 and 3129.
+
+## V. `iptables` Traffic Redirection
+
+To transparently redirect traffic from hotspot clients to the Squid proxy running in Docker, you need to apply `iptables` rules on the Raspberry Pi host.
+
+1.  **Locate the Script:**
+    The script `scripts/redirect_to_squid.sh` (from the main `scripts` directory in your cloned repository) is designed for this.
+
+2.  **Make it Executable:**
+    ```bash
+    chmod +x path/to/your/cloned/repository/scripts/redirect_to_squid.sh
+    ```
+
+3.  **Run the Script:**
+    Execute it with `sudo` privileges:
+    ```bash
+    sudo path/to/your/cloned/repository/scripts/redirect_to_squid.sh
+    ```
+    This script adds rules to the `nat` table's `PREROUTING` chain to redirect HTTP (port 80) and HTTPS (port 443) traffic from `wlan0` clients to Squid's respective ports (3128 and 3129) on the host machine.
+
+4.  **Docker Networking and `127.0.0.1`:**
+    The `iptables` rules redirect traffic to `127.0.0.1` (localhost) on the Raspberry Pi. Docker, through its port mappings defined in `docker-compose.yml` (e.g., `ports: - "3128:3128"`), makes the Squid container's ports accessible on the host's `127.0.0.1` interface. This is a standard method for redirecting host traffic to a Docker container.
+    The script also includes rules to allow traffic *to* the Pi-hole/RPi itself on `wlan0` (DNS, DHCP, captive portal) to bypass this redirection.
+
+5.  **Persistence:**
+    The `iptables` rules are volatile and will be lost on reboot.
+    *   If you installed `iptables-persistent` during the hotspot setup, save the current rules:
+        ```bash
+        sudo netfilter-persistent save
+        ```
+    *   If you modify rules or run other `iptables` scripts, remember to re-save.
+
+## VI. Testing and Verification
+
+1.  **Connect a Client:** Connect a device to the `rpi` Wi-Fi hotspot.
+2.  **Install CA Certificate:** On this client device, install and trust the `myCA.crt` you generated.
+3.  **Test HTTP:** Browse to an HTTP website (e.g., `http://example.com`). Check Squid's access log:
+    ```bash
+    sudo tail -f /mnt/usbdata/Berezino_Checkpoint/logs/access.log
+    # Or via Docker:
+    # docker logs -f Berezino_Checkpoint
+    ```
+    You should see log entries for the HTTP request.
+4.  **Test HTTPS:** Browse to an HTTPS website (e.g., `https://google.com`).
+    *   If the CA certificate is correctly installed and trusted on the client, the site should load without errors.
+    *   Check Squid's logs. You should see CONNECT requests being "bumped."
+    *   Inspect the website's certificate in your browser. It should be issued by "BerezinoCheckpointCA" (or whatever CN you used).
+5.  **Check Pi-hole:** Ensure DNS queries from the client (and from Squid itself) are still going through Pi-hole.
+
+## VII. Stopping Squid
+
+To stop the Squid proxy:
+```bash
+cd path/to/your/cloned/repository/squid_Berezino_Checkpoint/
+docker-compose down
+```
+Remember that `iptables` rules will remain until reboot or manually flushed/removed. If you stop Squid, you might want to remove or disable the redirection rules to restore direct internet access for hotspot clients.
+
+## Troubleshooting:
+
+*   **Squid Not Starting:** Check `docker logs Berezino_Checkpoint`. Common issues:
+    *   Incorrect `squid.conf` syntax.
+    *   `sslcrtd_program` path incorrect.
+    *   Permissions issues with volume mounts (`/mnt/usbdata/...`).
+    *   CA certificate (`myCA.pem`) missing or incorrectly formatted in `./certs/`.
+*   **Clients Get Certificate Errors:**
+    *   The `myCA.crt` is not installed or not trusted on the client device.
+    *   The `myCA.pem` used by Squid is different from the `myCA.crt` distributed to clients.
+    *   `ssl_bump` rules in `squid.conf` are misconfigured.
+*   **No Internet on Clients:**
+    *   `iptables` redirection rules are incorrect or not applied.
+    *   Squid is not running or not accessible.
+    *   Outbound internet connectivity for Squid itself is blocked (check Raspberry Pi's main FORWARD rules and NAT setup from `setup_hotspot_nat.sh`).
+    *   DNS resolution is failing for Squid (ensure `dns_nameservers 192.168.73.1` in `squid.conf` is correct and Pi-hole is working).
+*   **Traffic Not Being Logged by Squid:**
+    *   `iptables` rules are not correctly redirecting traffic.
+    *   `acl localnet` in `squid.conf` does not match your hotspot network.
+*   **Performance Issues:**
+    *   Transparent proxying, especially SSL bumping, adds overhead. The Raspberry Pi 5 should handle a small number of clients, but monitor CPU/memory usage.
+    *   Adjust `cache_mem` and `cache_dir` size in `squid.conf` as needed.
+
+This completes the setup for the `Berezino_Checkpoint` Squid proxy.

--- a/squid_Berezino_Checkpoint/certs/.gitkeep
+++ b/squid_Berezino_Checkpoint/certs/.gitkeep
@@ -1,0 +1,3 @@
+# This file is here to ensure the 'certs' directory is tracked by Git.
+# Place your myCA.pem (or equivalent CA certificate and key) in this directory
+# for Squid SSL Bumping. See the main guidance document for details.

--- a/squid_Berezino_Checkpoint/docker-compose.yml
+++ b/squid_Berezino_Checkpoint/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  berezino_checkpoint:
+    image: ubuntu/squid # Official Squid image, supports arm64
+    container_name: Berezino_Checkpoint
+    hostname: berezino-checkpoint # Thematic hostname
+    restart: unless-stopped
+    ports:
+      - "3128:3128" # Default Squid HTTP port
+      - "3129:3129" # Squid HTTPS/SSL-Bump port (or other as configured in squid.conf)
+      # - "3130:3130" # Squid ICAP port (if ever needed)
+    volumes:
+      - ./squid.conf:/etc/squid/squid.conf # Mount custom squid.conf
+      - ./certs:/etc/squid/certs # For SSL CA certificate and key
+      - /mnt/usbdata/Berezino_Checkpoint/cache:/var/spool/squid # Squid cache
+      - /mnt/usbdata/Berezino_Checkpoint/logs:/var/log/squid # Squid logs
+    cap_add:
+      - NET_ADMIN # Required for some transparent proxying features and tproxy
+    # networks:
+    #   # If you have a custom Docker network for your services, define and assign it here.
+    #   # For now, it will use the default bridge network.
+    #   # Ensure the RPi host can route traffic from wlan0 to Docker's network.
+    #   proxy_network:
+
+# networks:
+#   proxy_network:
+#     driver: bridge

--- a/squid_Berezino_Checkpoint/squid.conf
+++ b/squid_Berezino_Checkpoint/squid.conf
@@ -1,0 +1,88 @@
+# === NETWORK CONFIGURATION ===
+# Port for incoming HTTP requests, set to transparent mode
+http_port 3128 transparent
+
+# Port for incoming HTTPS requests, using ssl-bump
+# User MUST generate a CA certificate (e.g., myCA.pem) and private key (myCA.key)
+# and place them in the ./certs directory mapped in docker-compose.yml
+# The .pem should contain both cert and key or use cert= and key= separately.
+https_port 3129 intercept ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=4MB cert=/etc/squid/certs/myCA.pem key=/etc/squid/certs/myCA.key
+
+# Define SSL bump actions
+# Step 1: Peek at the SNI
+ssl_bump peek step1 all
+# Step 2: Splice known safe sites (optional, maintain a whitelist)
+# acl safe_sites ssl::server_name .example.com .anotherdomain.org
+# ssl_bump splice step2 safe_sites
+# Step 3: Bump (decrypt and re-encrypt) everything else
+ssl_bump bump all
+
+# Configure options for dynamically generated certificates
+sslcrtd_program /usr/lib/squid/security_file_certgen -s /var/lib/squid/ssl_db -M 4MB
+# Note: Path to security_file_certgen might vary by Squid version/distro.
+# For ubuntu/squid, it's often /usr/lib/squid/security_file_certgen or /usr/lib/squid3/security_file_certgen
+# Verify this path if there are issues. The Docker image should have it.
+
+# === ACCESS CONTROL ===
+acl localnet src 192.168.73.0/24 # Hotspot client network
+
+# Allow localnet access
+http_access allow localnet
+
+# Deny all other access to this proxy
+http_access deny all
+
+# === CACHE AND LOGGING ===
+# Cache directory (matches docker-compose volume)
+cache_dir ufs /var/spool/squid 1024 16 256 # 1GB cache, tune as needed
+
+# Log locations (match docker-compose volumes)
+access_log daemon:/var/log/squid/access.log squid
+cache_log /var/log/squid/cache.log
+cache_store_log /var/log/squid/store.log
+
+# === OTHER SETTINGS ===
+# Set visible hostname (thematic)
+visible_hostname Berezino_Checkpoint
+
+# Add a forwarded-for header
+forwarded_for on
+
+# Recommended: Do not log specific sensitive headers (if any)
+# request_header_access Authorization allow all
+# request_header_access Proxy-Authorization allow all
+# request_header_access Cache-Control allow all
+# ... and so on for other headers, then deny all others
+# request_header_access All deny all
+
+# Shutdown lifetime
+shutdown_lifetime 5 seconds
+
+# DNS servers (optional, Squid will use system DNS by default)
+# Using the Pi-hole instance on the RPi itself as the DNS resolver for Squid
+dns_nameservers 192.168.73.1
+# Fallback DNS servers (optional)
+# dns_nameservers 8.8.8.8 1.1.1.1
+
+# Ensure Squid can resolve .hotspot.chernarus (if needed for captive portal or other local services)
+# This is usually handled by the system resolver, which should point to Pi-hole.
+# Forcing a domain search list (if necessary, usually not for this setup)
+# dns_search_domains hotspot.chernarus
+
+# SSL Bump settings related to certificate validation errors
+# By default, Squid tries to validate upstream certificates.
+# If using a self-signed cert for the CA, this is fine.
+# If upstream sites have errors, Squid will show an error.
+# To ignore upstream cert errors (less secure, use with caution):
+# sslproxy_cert_error allow all
+
+# Minimum TLS/SSL version to use for server connections
+# Consider security best practices; TLS 1.2 is a common minimum.
+# sslproxy_options MIN_VERSION=tls1.2
+
+# Cipher suite for server connections (if specific control is needed)
+# sslproxy_cipher HIGH:MEDIUM:!LOW:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1
+
+# Client-side TLS options (for bumped connections)
+# client_tls_version_options MIN_VERSION=tls1.2
+# client_tls_cipher_options HIGH:MEDIUM:!LOW:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1


### PR DESCRIPTION
This commit introduces the initial configurations for "Operación: The Perimeter," establishing a Wi-Fi hotspot, Squid proxy, and a captive portal on the Raspberry Pi.

**1. Wi-Fi Hotspot (`Chernarus_Beacon`):**
    - Configured `hostapd` for `wlan0` with WPA2 security (SSID: `rpi`).
    - Integrated DHCP services with Pi-hole (`StarySobor_RadioPost`) via a custom `dnsmasq` configuration for the `192.168.73.0/24` hotspot network.
    - Provided `iptables` script (`setup_hotspot_nat.sh`) for NAT and traffic forwarding from `wlan0` to `eth0`.
    - Includes `GUIDANCE_AND_EXPLANATIONS.md` for setup.

**2. Squid Proxy (`Berezino_Checkpoint`):**
    - Docker Compose setup for Squid (`ubuntu/squid` image, arm64 compatible).
    - Persistent storage for logs and cache mapped to `/mnt/usbdata/Berezino_Checkpoint/`.
    - `squid.conf` tailored for transparent HTTP and HTTPS (SSL Bumping) proxying for the hotspot network. Includes placeholders and guidance for CA certificate setup.
    - `iptables` script (`redirect_to_squid.sh`) to redirect hotspot client traffic (ports 80, 443) to Squid.
    - Includes `README_SQUID.md` for setup and CA certificate guidance.

**3. Simplified Captive Portal (`Chernarus_Entrypoint`):**
    - Docker Compose setup for a lightweight Nginx portal (`nginx:alpine`, arm64 compatible) on port 8080.
    - Basic `index.html` page to guide users on downloading and installing the CA certificate required for Squid's SSL Bumping.
    - `iptables` script (`setup_captive_portal_redirect.sh`) to redirect new hotspot users (HTTP traffic) to the portal.
    - Includes `README_PORTAL.md` for setup.

**General Notes:**
    - All configurations are designed for a Raspberry Pi 5 (linux/arm64/v8).
    - Thematic naming conventions have been applied as per the project description.
    - Assumes Pi-hole is operational for DNS and DHCP integration.
    - You MUST set Wi-Fi password and generate/distribute CA certificates.
    - Detailed deployment steps and guidance are provided in the respective READMEs and the main `GUIDANCE_AND_EXPLANATIONS.md`.

This implementation fulfills the core requirements for setting up the network perimeter as outlined in the issue. Further refinements and integration with Traefik/Cloudflare can be addressed in subsequent phases.