### PR TITLE
This commit introduces a comprehensive guide and the necessary script…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,79 @@
+# Workflow name
+name: CI/CD Hugo Site to Raspberry Pi
+
+# Triggers: This workflow runs on pushes to the main branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Build job: Builds the Hugo site using a GitHub-hosted runner
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Checkout the repository code
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true  # Checkout submodules if any (e.g., themes)
+
+      # Step 2: Setup Hugo
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.110.0' # Specify Hugo version
+          extended: true          # Use Hugo extended version
+
+      # Step 3: Build the Hugo site
+      - name: Build Hugo site
+        run: hugo --minify # Build the site and minify output
+
+      # Step 4: Upload the build artifact (the 'public' directory)
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: hugo-site-public # Name of the artifact
+          path: public          # Path to the directory to upload
+
+  # Deploy job: Deploys the built site to the self-hosted Raspberry Pi runner
+  deploy:
+    runs-on: self-hosted # This job runs on the self-hosted runner (Raspberry Pi)
+    needs: build         # This job depends on the successful completion of the 'build' job
+    steps:
+      # Step 1: Download the build artifact
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: hugo-site-public # Name of the artifact to download
+          path: ./downloaded-site # Destination path for the downloaded artifact
+
+      # Step 2: Deploy to Nginx (or other web server)
+      # This step assumes you have a 'deploy.sh' script in your repository root
+      # and that your self-hosted runner has permissions to execute it and
+      # place files in the web server's root directory.
+      - name: Deploy to Nginx
+        run: |
+          echo "Starting deployment..."
+          if [ -f ./deploy.sh ]; then
+            chmod +x ./deploy.sh
+            sh ./deploy.sh ./downloaded-site
+            echo "Deployment script executed."
+          else
+            echo "ERROR: deploy.sh not found!"
+            exit 1
+          fi
+        # Example of what deploy.sh might contain:
+        # #!/bin/bash
+        # # Check if source directory is provided
+        # if [ -z "$1" ]; then
+        #   echo "Usage: $0 <source_directory>"
+        #   exit 1
+        # fi
+        # SOURCE_DIR="$1"
+        # TARGET_DIR="/var/www/html" # Adjust to your Nginx web root
+        # echo "Cleaning target directory: $TARGET_DIR"
+        # sudo rm -rf "$TARGET_DIR"/*
+        # echo "Copying new site files from $SOURCE_DIR to $TARGET_DIR"
+        # sudo cp -r "$SOURCE_DIR"/* "$TARGET_DIR"/
+        # echo "Deployment finished."

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# --- Error Handling ---
+# Exit immediately if a command exits with a non-zero status.
+set -e
+# Cause a pipeline to return the exit status of the last command in the pipe that failed.
+set -o pipefail
+
+# --- Script Configuration ---
+# NGINX_WEB_ROOT: The directory where Nginx serves files for this site.
+# This path is standard for user-deployed sites on Arch Linux (under /srv/http/).
+# IMPORTANT:
+# 1. This directory will be created by the script if it doesn't exist.
+# 2. The 'github-runner' user (or the user executing this script) needs sudo privileges
+#    to create this directory, run rsync with delete, chown, chmod, and restart nginx.
+NGINX_WEB_ROOT="/srv/http/surviving-chernarus"
+
+# --- Input Parameter Validation ---
+# Check if the path to the downloaded artifact is provided as the first argument.
+if [ -z "$1" ]; then
+  echo "Error: No artifact path provided."
+  echo "Usage: $0 <path_to_artifact>"
+  exit 1
+fi
+
+# Store the artifact path from the first argument.
+ARTIFACT_PATH="$1"
+echo "Artifact path: $ARTIFACT_PATH"
+
+# --- Deployment Steps ---
+echo "Starting deployment to Nginx web root: $NGINX_WEB_ROOT ..."
+
+# 1. Create Nginx web root directory if it doesn't exist.
+#    The -p flag ensures that parent directories are also created if needed,
+#    and it doesn't error if the directory already exists.
+echo "Ensuring Nginx web root directory exists: $NGINX_WEB_ROOT"
+sudo mkdir -p "$NGINX_WEB_ROOT"
+
+# 2. Clear existing content from Nginx web root and copy new site files.
+#    Using rsync with --delete is an efficient way to synchronize the content.
+#    The source path "$ARTIFACT_PATH/" (with a trailing slash) means "copy the contents
+#    of ARTIFACT_PATH".
+#    The destination path "$NGINX_WEB_ROOT/" ensures files are placed directly into it.
+#    --delete will remove any files in $NGINX_WEB_ROOT that are not in $ARTIFACT_PATH.
+echo "Clearing old content and copying new site files from $ARTIFACT_PATH to $NGINX_WEB_ROOT ..."
+sudo rsync -a --delete "$ARTIFACT_PATH/" "$NGINX_WEB_ROOT/"
+
+# 3. Set appropriate permissions for the web files.
+#    This is crucial for security and for Nginx to be able to read the files.
+#    On Arch Linux, Nginx typically runs as the 'http' user and group.
+echo "Setting permissions for $NGINX_WEB_ROOT ..."
+# Set ownership to http:http
+sudo chown -R http:http "$NGINX_WEB_ROOT"
+# Set directory permissions to 755 (rwxr-xr-x)
+sudo find "$NGINX_WEB_ROOT" -type d -exec chmod 755 {} \;
+# Set file permissions to 644 (rw-r--r--)
+sudo find "$NGINX_WEB_ROOT" -type f -exec chmod 644 {} \;
+
+# 4. Restart Nginx to apply changes.
+#    This ensures that Nginx serves the new files.
+echo "Restarting Nginx service ..."
+sudo systemctl restart nginx
+
+echo "-------------------------------------"
+echo "Deployment completed successfully!"
+echo "Site deployed to: $NGINX_WEB_ROOT"
+echo "-------------------------------------"
+
+exit 0

--- a/wiki/es/12-Configuracion-Runner-Autoalojado.md
+++ b/wiki/es/12-Configuracion-Runner-Autoalojado.md
@@ -1,0 +1,217 @@
+# Configuración del Runner Auto-Alojado en Raspberry Pi (Arch Linux)
+
+## Introducción
+Un runner auto-alojado (self-hosted runner) es una aplicación que instalas y ejecutas en tu propia infraestructura (en este caso, tu Raspberry Pi) para procesar trabajos (jobs) de tus flujos de trabajo de GitHub Actions. Para nuestro flujo de CI/CD, donde queremos desplegar el sitio Hugo compilado en la Raspberry Pi que también sirve como servidor web, un runner auto-alojado es esencial. Permite que GitHub Actions interactúe directamente con el entorno de despliegue.
+
+Este documento te guiará a través de la instalación y configuración de un runner auto-alojado en tu Raspberry Pi 5 con Arch Linux.
+
+## Prerrequisitos en la Raspberry Pi
+Antes de configurar el runner, asegúrate de que tu sistema Arch Linux en la Raspberry Pi esté preparado:
+
+1.  **Sistema Actualizado:**
+    Es crucial tener el sistema al día. Abre una terminal y ejecuta:
+    ```bash
+    sudo pacman -Syu
+    ```
+
+2.  **Git:**
+    Necesario para que el runner clone repositorios.
+    ```bash
+    sudo pacman -S --noconfirm --needed git
+    ```
+    (`--noconfirm` evita la pregunta y `--needed` solo instala si no está presente o es una versión más antigua).
+
+3.  **GitHub CLI (`gh`):**
+    Útil para interactuar con GitHub desde la línea de comandos, especialmente para la autenticación.
+    ```bash
+    sudo pacman -S --noconfirm --needed github-cli
+    ```
+
+4.  **Herramientas de Descarga y Compresión:**
+    `curl` para descargar el software del runner y `tar` para extraerlo.
+    ```bash
+    sudo pacman -S --noconfirm --needed tar curl
+    ```
+
+5.  **`jq` (Opcional pero recomendado):**
+    Una herramienta para procesar JSON, útil para extraer información como la URL de descarga del runner.
+    ```bash
+    sudo pacman -S --noconfirm --needed jq
+    ```
+
+6.  **Servidor Web Nginx:**
+    Nginx servirá nuestro sitio Hugo.
+    ```bash
+    sudo pacman -S --noconfirm --needed nginx
+    ```
+    *   **Habilitar e Iniciar Nginx:**
+        Para que Nginx se inicie automáticamente con el sistema y arranque ahora:
+        ```bash
+        sudo systemctl enable --now nginx
+        ```
+    *   **Verificar Nginx:**
+        Abre un navegador web en una computadora de tu red local y navega a la dirección IP de tu Raspberry Pi (e.g., `http://DIRECCION_IP_RASPBERRY_PI`). Deberías ver la página de bienvenida de Nginx ("Welcome to nginx!").
+
+7.  **Opcional: Hugo:**
+    Aunque el flujo de trabajo propuesto (Opción A) construye el sitio en un runner alojado por GitHub, podrías querer instalar Hugo en la Raspberry Pi para pruebas locales o como parte de un script de despliegue más complejo.
+    ```bash
+    sudo pacman -S --noconfirm --needed hugo
+    ```
+
+## Crear un Usuario Dedicado para el Runner (Recomendado)
+Por razones de seguridad, es una mala práctica ejecutar el runner de GitHub Actions con el usuario `root` o con tu usuario personal. Crear un usuario dedicado con privilegios limitados es la mejor opción.
+
+1.  **Crear el usuario `github-runner`:**
+    ```bash
+    sudo useradd -m -s /bin/bash github-runner
+    ```
+    *   `-m`: Crea el directorio home del usuario (e.g., `/home/github-runner`).
+    *   `-s /bin/bash`: Establece bash como el shell por defecto.
+
+2.  **Establecer una contraseña para el nuevo usuario:**
+    ```bash
+    sudo passwd github-runner
+    ```
+    Sigue las instrucciones para crear una contraseña segura. Alternativamente, si solo vas a acceder a este usuario mediante `sudo -u github-runner ...` o SSH con claves, una contraseña local podría no ser estrictamente necesaria, pero es una buena práctica tenerla.
+
+3.  **Permisos `sudo` (con precaución):**
+    El runner en sí mismo no debería necesitar permisos `sudo` para sus operaciones normales. Sin embargo, tu *script de despliegue* (e.g., `deploy.sh`) que el runner ejecutará sí podría necesitar `sudo` para copiar archivos al directorio raíz de Nginx (e.g., `/var/www/html/`) y para reiniciar el servicio Nginx.
+
+    La mejor práctica es que el script `deploy.sh` maneje los comandos `sudo` internamente. Por ejemplo, el script podría empezar con una verificación de que se ejecuta con `sudo` o llamar a `sudo` para comandos específicos.
+
+    Si necesitas que el usuario `github-runner` pueda ejecutar ciertos comandos específicos sin contraseña, puedes usar `visudo`. Por ejemplo, para permitir reiniciar Nginx y usar `rsync` (solo como ejemplo ilustrativo, **adapta esto cuidadosamente a tus necesidades y script de despliegue**):
+    ```bash
+    # sudo visudo
+    ```
+    Y añadir una línea como:
+    `github-runner ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart nginx, /usr/bin/cp, /usr/bin/rm`
+    **Advertencia:** `NOPASSWD` debe usarse con extrema precaución y solo para comandos muy específicos y seguros. Es preferible que el script de despliegue sea el que pida `sudo` si es necesario, o que el runner ejecute un script que ya tenga los permisos adecuados (por ejemplo, mediante `sudo` en el propio comando del workflow, aunque esto también tiene implicaciones de seguridad).
+
+    Para el propósito de esta guía, asumiremos que el `deploy.sh` que el runner invoca manejará los permisos `sudo` necesarios internamente.
+
+## Instalar y Configurar el Runner de GitHub Actions
+La instalación se realiza como el usuario `github-runner` en su directorio home.
+
+1.  **Navega a GitHub para obtener instrucciones y token:**
+    *   En tu navegador, ve a tu repositorio: `https://github.com/terrerovgh/surviving-chernarus`
+    *   Haz clic en "Settings" (Configuración).
+    *   En el menú de la izquierda, ve a "Actions" y luego a "Runners".
+    *   Haz clic en el botón "New self-hosted runner".
+    *   Selecciona "Linux" como sistema operativo y "ARM64" como arquitectura.
+    *   GitHub te proporcionará una serie de comandos, incluyendo un token de registro. **Este token es sensible y único para tu repositorio.**
+
+2.  **Pasos Generales (ejecutados como `github-runner`):**
+    Los siguientes comandos son una guía basada en lo que GitHub proporciona. Asegúrate de usar los comandos exactos y el token de la página de GitHub.
+
+    *   **Crear directorio para el runner y navegar a él:**
+        Estos comandos deben ejecutarse como el usuario `github-runner`. Puedes cambiar a este usuario con `su - github-runner` o prefijar los comandos con `sudo -u github-runner sh -c '...'`.
+        ```bash
+        sudo -u github-runner mkdir -p /home/github-runner/actions-runner
+        cd /home/github-runner/actions-runner
+        ```
+        **Nota:** A partir de aquí, los siguientes comandos de descarga y configuración se deben ejecutar en este directorio (`/home/github-runner/actions-runner`) **y como el usuario `github-runner`**. Para ello, puedes abrir una sesión shell como `github-runner`:
+        ```bash
+        sudo su - github-runner
+        # Ahora estás como el usuario github-runner en su home.
+        # Navega al directorio creado si no estás ya allí:
+        cd /home/github-runner/actions-runner
+        ```
+
+    *   **Descargar el último paquete del runner:**
+        (Los siguientes comandos asumen que estás operando como `github-runner` en el directorio `/home/github-runner/actions-runner`)
+        ```bash
+        # Obtener la última versión del runner
+        export RUNNER_VERSION=$(curl -s -L https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name' | sed 's/v//')
+        # Descargar el paquete
+        curl -L -o actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz
+        ```
+        Verifica que la arquitectura sea `arm64` para la Raspberry Pi 5.
+
+    *   **Verificar el hash (opcional pero recomendado):**
+        GitHub proporciona un hash SHA256 para el paquete. Puedes verificarlo con:
+        ```bash
+        echo "<HASH_PROPORCIONADO_POR_GITHUB> actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz" | sha256sum -c
+        ```
+        Debería indicar "OK".
+
+    *   **Extraer el instalador:**
+        ```bash
+        tar xzf ./actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz
+        ```
+
+    *   **Configurar el runner:**
+        Aquí es donde usarás el token que obtuviste de la página de GitHub.
+        **¡NO PEGUES TU TOKEN DIRECTAMENTE EN SCRIPTS QUE SUBAS AL REPOSITORIO!**
+        ```bash
+        ./config.sh --url https://github.com/terrerovgh/surviving-chernarus --token TU_TOKEN_DE_REGISTRO_AQUI
+        ```
+        Sigue las instrucciones:
+        *   **Enter the name of runner group to add this runner to:** Presiona Enter para el default.
+        *   **Enter the name of runner to use:** Sugiere un nombre descriptivo, e.g., `rp5-arch-surviving-chernarus`.
+        *   **Enter any additional labels (comma separated):** Sugiere `self-hosted,linux,arm64`. El flujo de trabajo (`main.yml`) usará `self-hosted` para seleccionar este runner.
+        *   **Enter name of work folder:** Presiona Enter para el default (`_work`).
+
+## Ejecutar el Runner como un Servicio (systemd)
+Para que el runner se ejecute de forma continua y se reinicie automáticamente, es mejor configurarlo como un servicio `systemd`. Los siguientes comandos se ejecutan desde el directorio del runner (`/home/github-runner/actions-runner`), pero el comando `svc.sh` necesita `sudo` para instalar el servicio.
+
+1.  **Instalar el servicio:**
+    Este comando debe ejecutarse desde el directorio donde extrajiste y configuraste el runner (e.g., `/home/github-runner/actions-runner`). El `github-runner` al final del comando es el nombre del usuario bajo el cual se ejecutará el servicio.
+    ```bash
+    sudo ./svc.sh install github-runner
+    ```
+
+2.  **Iniciar el servicio:**
+    El nombre del servicio se genera basado en tu repositorio y nombre de runner. Puedes encontrar el nombre exacto con `systemctl list-units | grep actions.runner`.
+    Un ejemplo del nombre podría ser: `actions.runner.terrerovgh.surviving-chernarus.rp5-arch-surviving-chernarus.service`.
+    ```bash
+    sudo systemctl start NOMBRE_DEL_SERVICIO_DEL_RUNNER
+    ```
+    Reemplaza `NOMBRE_DEL_SERVICIO_DEL_RUNNER` con el nombre real.
+
+3.  **Habilitar para inicio automático:**
+    ```bash
+    sudo systemctl enable NOMBRE_DEL_SERVICIO_DEL_RUNNER
+    ```
+
+4.  **Verificar el estado del servicio:**
+    ```bash
+    sudo systemctl status NOMBRE_DEL_SERVICIO_DEL_RUNNER
+    ```
+    Deberías ver que está "active (running)". También puedes revisar los logs con `journalctl -u NOMBRE_DEL_SERVICIO_DEL_RUNNER -f`.
+
+    Una vez que el servicio esté corriendo, deberías ver tu runner listado como "Idle" en la sección "Settings" > "Actions" > "Runners" de tu repositorio en GitHub.
+
+## Consideraciones de Seguridad y Mantenimiento
+
+*   **Permisos del Runner:** Ejecuta siempre el runner con un usuario de privilegios mínimos (`github-runner` en este caso). Evita darle más permisos `sudo` de los estrictamente necesarios.
+*   **Actualizaciones del Runner:** El software del runner se actualiza periódicamente. GitHub Actions generalmente maneja esto indicando cuándo una versión es obsoleta. Puede que necesites descargar la nueva versión y reconfigurar el servicio. Revisa los logs del runner y la interfaz de GitHub para notificaciones.
+*   **Seguridad del Token de Registro:** Aunque el token de registro se usa una sola vez para conectar el runner, el runner tiene acceso a un `GITHUB_TOKEN` con permisos sobre el repositorio durante la ejecución de los workflows. Asegúrate de que el runner solo pueda ejecutar los scripts y comandos necesarios.
+*   **Acceso a la Red:** La Raspberry Pi debe tener acceso saliente a `github.com` y a las URLs de descarga de artefactos (generalmente `*.actions.githubusercontent.com`).
+*   **Firewall:** Si tienes un firewall configurado en la Raspberry Pi (como `ufw` o `iptables`), asegúrate de que no bloquea las conexiones salientes necesarias para el runner. Para `ufw`, el tráfico saliente suele estar permitido por defecto.
+
+## Autenticación de GitHub CLI (`gh`) en la Raspberry Pi (para el usuario `github-runner`)
+Aunque el script de despliegue básico (copiar artefactos) podría no necesitar `gh` directamente, tenerlo autenticado para el usuario `github-runner` es útil para mantenimiento, diagnósticos o futuras necesidades de scripting que interactúen con la API de GitHub.
+
+1.  **Iniciar sesión como `github-runner`:**
+    ```bash
+    sudo -u github-runner gh auth login
+    ```
+2.  **Sigue las instrucciones:**
+    *   **What account do you want to log into?** Selecciona `GitHub.com`.
+    *   **What is your preferred protocol for Git operations?** Selecciona `HTTPS` (o `SSH` si has configurado claves SSH para el usuario `github-runner`).
+    *   **Authenticate Git with your GitHub credentials?** Selecciona `Y` (Yes).
+    *   **How would you like to authenticate?** Selecciona `Paste an authentication token`.
+3.  **Obtener un Personal Access Token (PAT):**
+    *   En GitHub, ve a "Settings" (tu perfil, no el del repo) > "Developer settings" > "Personal access tokens" > "Tokens (classic)".
+    *   Haz clic en "Generate new token" (o "Generate new token (classic)").
+    *   Dale un nombre descriptivo (e.g., `gh-runner-rpi`).
+    *   Selecciona la expiración deseada.
+    *   Selecciona los scopes. Para la mayoría de usos de `gh` relacionados con el repositorio, el scope `repo` es suficiente.
+    *   Haz clic en "Generate token". **Copia el token inmediatamente, no podrás volver a verlo.**
+4.  **Pegar el token en la terminal:**
+    Pega el PAT copiado en la terminal donde `gh auth login` lo solicita.
+5.  `gh` almacenará el token de forma segura en el directorio home del usuario `github-runner`.
+
+Con esto, el usuario `github-runner` está autenticado para usar `gh` en la Raspberry Pi.
+
+¡Felicidades! Ahora tienes un runner auto-alojado configurado en tu Raspberry Pi, listo para ejecutar los trabajos de despliegue de tu flujo de CI/CD.

--- a/wiki/es/13-GitHub-CLI-Autenticacion.md
+++ b/wiki/es/13-GitHub-CLI-Autenticacion.md
@@ -1,0 +1,155 @@
+# Uso y Autenticación de GitHub CLI (`gh`) en la Raspberry Pi
+
+## Introducción
+GitHub CLI (`gh`) es la herramienta oficial de línea de comandos para interactuar con tu cuenta de GitHub directamente desde la terminal. En el contexto de nuestra Raspberry Pi configurada como un runner auto-alojado, `gh` se convierte en una utilidad muy poderosa.
+
+Aunque nuestro script de despliegue (`deploy.sh`) actual no utiliza `gh` directamente para copiar los archivos del sitio, `gh` es fundamental para:
+*   **Autenticar el runner con GitHub:** Facilita la configuración inicial y la interacción con la API de GitHub.
+*   **Administración del Repositorio:** Permite realizar tareas como clonar repositorios, gestionar Pull Requests, issues, releases, y más, directamente desde la Raspberry Pi.
+*   **Gestión de Workflows:** Se puede usar para ver el estado de los workflows, descargar artefactos manualmente si es necesario, o incluso disparar workflows.
+*   **Diagnóstico y Mantenimiento:** Útil para verificar el estado de la conexión con GitHub o para realizar tareas de mantenimiento relacionadas con el repositorio o las acciones.
+
+Esta guía te mostrará cómo instalar y autenticar `gh` para el usuario `github-runner` en tu Raspberry Pi con Arch Linux.
+
+## Instalación de GitHub CLI (Arch Linux)
+Si seguiste la guía de configuración del runner auto-alojado, `gh` ya debería estar instalado como parte de los prerrequisitos. Si no es así, o para confirmar:
+
+1.  **Instalar `gh`:**
+    Abre una terminal en tu Raspberry Pi y ejecuta:
+    ```bash
+    sudo pacman -S --noconfirm --needed github-cli
+    ```
+    *   `--noconfirm`: Evita la solicitud de confirmación.
+    *   `--needed`: Solo instala si el paquete no está presente o si hay una versión más nueva disponible.
+
+2.  **Verificar la instalación:**
+    Para confirmar que `gh` está instalado y ver su versión:
+    ```bash
+    gh --version
+    ```
+    Esto debería mostrar la versión de `gh` instalada, por ejemplo: `gh version 2.XX.X (YYYY-MM-DD)`.
+
+## Autenticación de `gh` (para el usuario `github-runner`)
+La autenticación de `gh` debe realizarse con el usuario que efectivamente utilizará la herramienta. En nuestro caso, es el usuario `github-runner` que hemos creado para el servicio de GitHub Actions.
+
+### Paso 1: Iniciar sesión como `github-runner`
+Si estás operando como `root` o tu usuario personal, necesitas cambiar al usuario `github-runner` para realizar la autenticación en su contexto. La forma más limpia de hacerlo es iniciar una sesión interactiva como `github-runner`:
+
+```bash
+sudo -iu github-runner
+```
+*   `sudo`: Ejecuta el comando como superusuario.
+*   `-i`: Simula un inicio de sesión inicial, cargando el entorno del usuario `github-runner` (incluyendo su directorio home, `$HOME`).
+*   `-u github-runner`: Especifica que el comando se ejecute como el usuario `github-runner`.
+
+Después de ejecutar este comando, tu prompt cambiará, indicando que ahora estás operando como `github-runner` (e.g., `[github-runner@hostname ~]$`).
+
+### Paso 2: Proceso de Autenticación con `gh auth login`
+Una vez que estés como el usuario `github-runner`, inicia el proceso de autenticación:
+
+```bash
+gh auth login
+```
+
+`gh` te guiará a través de una serie de preguntas:
+
+1.  **What account do you want to log into?**
+    *   Selecciona: `GitHub.com` (esta es la opción por defecto si solo trabajas con github.com).
+
+2.  **What is your preferred protocol for Git operations?**
+    *   Selecciona: `HTTPS`
+    *   (Si has configurado claves SSH para el usuario `github-runner` y prefieres usarlas para operaciones `git`, podrías elegir `SSH`. Para la mayoría de los casos, `HTTPS` es más sencillo de configurar con tokens).
+
+3.  **Authenticate Git with your GitHub credentials?**
+    *   Selecciona: `Y` (Yes)
+    *   Esto es muy útil porque permite que los comandos `git clone`, `git push`, `git pull`, etc., que se ejecutan sobre HTTPS utilicen el token de `gh` automáticamente, sin necesidad de configurar gestores de credenciales de Git adicionales o ingresar tu token/contraseña manualmente para cada operación Git.
+
+4.  **How would you like to authenticate?**
+    *   Selecciona: `Paste an authentication token`
+    *   Esta opción es la más adecuada para entornos de servidor o runners, ya que no requiere abrir un navegador en la Raspberry Pi.
+
+A continuación, `gh` te pedirá que pegues el token.
+
+#### Obtener un Personal Access Token (PAT)
+
+Para obtener el token que necesitas pegar:
+
+1.  **Abre un navegador web** en tu computadora de escritorio o cualquier dispositivo con acceso a GitHub.
+2.  **Navega a GitHub y accede a tu cuenta.**
+3.  Ve a **Settings** (haz clic en tu foto de perfil en la esquina superior derecha).
+4.  En el menú de la izquierda, desplázate hacia abajo y haz clic en **Developer settings**.
+5.  En el menú de la izquierda de "Developer settings", haz clic en **Personal access tokens**, y luego selecciona **Tokens (classic)**.
+6.  Haz clic en el botón **Generate new token** (o **Generate new token (classic)**).
+7.  **Nota (Nombre del Token):** Asígnale un nombre descriptivo para que puedas identificarlo más tarde, por ejemplo: `gh-rpi-runner-surviving-chernarus`.
+8.  **Expiration (Expiración):** Establece una fecha de expiración adecuada para el token. Para un runner, podrías considerar una expiración más larga, pero ten en cuenta las implicaciones de seguridad. También puedes optar por no expiración, aunque es menos seguro.
+9.  **Scopes (Permisos):** Selecciona los permisos (scopes) que necesitará el token. Los scopes definen a qué puede acceder el token.
+    *   Para operaciones generales de repositorio y para que el runner interactúe con el repositorio (como clonar, reportar estado, etc.), el scope `repo` es fundamental. Este scope otorga control total sobre tus repositorios (privados y públicos).
+    *   Si planeas usar `gh` para gestionar workflows (e.g., `gh workflow run`), necesitarás el scope `workflow`.
+    *   **Para este caso, selecciona al menos `repo`.** Lee la descripción de cada scope cuidadosamente antes de seleccionarlo.
+10. Haz clic en el botón **Generate token** en la parte inferior de la página.
+11. **¡IMPORTANTE! Copia el token generado inmediatamente.** GitHub solo te mostrará el token una vez. No podrás volver a verlo. Guárdalo temporalmente en un lugar seguro hasta que lo pegues en la terminal.
+
+#### Pegar el Token en la Terminal
+
+Vuelve a la terminal de tu Raspberry Pi (donde `gh auth login` está esperando el token) y pega el Personal Access Token que acabas de copiar. Presiona Enter.
+
+### Paso 3: Verificar la Autenticación
+Después de pegar el token, `gh` intentará autenticarse con GitHub. Si todo es correcto, deberías ver un mensaje de éxito.
+
+Para confirmar que la autenticación ha sido exitosa y que `gh` puede acceder a tu información:
+
+1.  **Verificar el estado de la autenticación:**
+    ```bash
+    gh auth status
+    ```
+    Deberías ver una salida similar a esta, indicando que estás logueado a `github.com` como tu usuario y qué scopes tiene el token:
+    ```
+    github.com
+      ✓ Logged in to github.com as TuNombreDeUsuario (oauth_token)
+      ✓ Git operations for github.com configured to use https protocol.
+      ✓ Token: *******************
+      ✓ Token scopes: 'repo', 'workflow', ...
+    ```
+
+2.  **Verificar el acceso al repositorio:**
+    Intenta ver información de tu repositorio. Reemplaza `terrerovgh/surviving-chernarus` con tu nombre de usuario y repositorio si es diferente:
+    ```bash
+    gh repo view terrerovgh/surviving-chernarus
+    ```
+    Si el token tiene el scope `repo` y es válido, esto debería mostrar detalles sobre tu repositorio. Si falla, revisa los scopes de tu token o si hubo algún error al pegar el token.
+
+## Almacenamiento Seguro del Token por `gh`
+Una vez que te autenticas exitosamente, `gh` almacena el token de forma segura en un archivo de configuración dentro del directorio home del usuario que realizó la autenticación. Para el usuario `github-runner`, este archivo se encuentra en:
+
+`~/.config/gh/hosts.yml` (que se expande a `/home/github-runner/.config/gh/hosts.yml`)
+
+*   **No es necesario exponer el token en scripts:** Gracias a este almacenamiento, no necesitas incluir tu token directamente en scripts o variables de entorno para que `gh` funcione. `gh` lo leerá automáticamente desde este archivo.
+*   **Permisos del Archivo:** `gh` establece permisos restrictivos para este archivo (generalmente `600`, es decir, solo lectura y escritura para el propietario), lo cual es bueno para la seguridad. Asegúrate de que estos permisos no se modifiquen accidentalmente para ser más permisivos.
+
+## Uso Básico de `gh` (Ejemplos Opcionales)
+Ahora que `gh` está autenticado para el usuario `github-runner`, puedes usarlo para varias tareas. Aquí algunos ejemplos básicos:
+
+*   **Clonar un repositorio (si se quisiera hacer manualmente):**
+    ```bash
+    gh repo clone terrerovgh/surviving-chernarus
+    ```
+
+*   **Listar Pull Requests del repositorio:**
+    ```bash
+    gh pr list -R terrerovgh/surviving-chernarus
+    ```
+    (El flag `-R` es necesario si no estás dentro de un directorio de repositorio clonado).
+
+*   **Listar las ejecuciones de workflows recientes:**
+    ```bash
+    gh run list -R terrerovgh/surviving-chernarus
+    ```
+
+*   **Ver el estado de los runners del repositorio:**
+    ```bash
+    gh runner list -R terrerovgh/surviving-chernarus
+    ```
+
+Estos son solo algunos ejemplos. `gh` tiene una amplia gama de comandos y subcomandos que puedes explorar con `gh --help` o `gh [comando] --help`.
+
+Con `gh` correctamente instalado y autenticado para el usuario `github-runner`, tienes una herramienta robusta para la gestión y automatización de tareas relacionadas con GitHub en tu Raspberry Pi.

--- a/wiki/es/14-Gestion-Secretos.md
+++ b/wiki/es/14-Gestion-Secretos.md
@@ -1,0 +1,129 @@
+# Gestión de Secretos (Personal Access Tokens - PAT)
+
+## Introducción
+La gestión segura de "secretos" es un aspecto crítico de cualquier sistema de CI/CD y, en general, de cualquier software que interactúe con APIs o servicios protegidos. Los secretos son credenciales sensibles como contraseñas, claves API, y, en nuestro caso, Personal Access Tokens (PATs) de GitHub. Un manejo inadecuado de estos secretos puede llevar a accesos no autorizados y comprometer la seguridad de tus repositorios y servicios.
+
+En este proyecto, los PATs de GitHub son el principal tipo de secreto que manejamos. Consideraremos dos contextos principales donde estos secretos se utilizan y configuran:
+
+1.  **Secretos en GitHub Actions (Nivel de Repositorio):** Para información sensible que los flujos de trabajo (workflows) podrían necesitar si interactúan con servicios externos o la API de GitHub desde los runners alojados por GitHub.
+2.  **Secretos en la Raspberry Pi (Nivel de Runner Auto-Alojado):** Específicamente, el PAT utilizado para autenticar la herramienta `gh` (GitHub CLI) con el usuario `github-runner`.
+
+## Secretos en GitHub Actions
+
+### ¿Cuándo se usan?
+Los secretos de GitHub Actions se utilizan para almacenar información sensible que tu flujo de trabajo (definido en el archivo `.github/workflows/main.yml`) necesita para ejecutarse. Algunos ejemplos comunes incluyen:
+
+*   Claves API para servicios de terceros (e.g., servicios de notificación, plataformas en la nube).
+*   Tokens de acceso para registros de Docker.
+*   **Personal Access Tokens (PATs) de GitHub:** Si un paso de tu workflow que se ejecuta en un runner alojado por GitHub (no en tu Raspberry Pi) necesitara realizar llamadas a la API de GitHub con privilegios específicos (por ejemplo, para crear un issue, modificar un release, etc.).
+
+El `GITHUB_TOKEN` que GitHub proporciona automáticamente a cada workflow tiene permisos limitados al repositorio donde se ejecuta. Si necesitas más permisos o interactuar con otros repositorios, un PAT configurado como secreto sería necesario.
+
+### Cómo configurarlos:
+Para configurar un secreto a nivel de repositorio:
+
+1.  Navega a tu repositorio en GitHub: `https://github.com/terrerovgh/surviving-chernarus`
+2.  Haz clic en la pestaña **Settings** (Configuración).
+3.  En el menú de la izquierda, bajo la sección "Security", haz clic en **Secrets and variables**, y luego en **Actions**.
+4.  En la pestaña "Secrets", haz clic en el botón **New repository secret**.
+5.  **Name (Nombre del secreto):**
+    *   Elige un nombre descriptivo para tu secreto, por ejemplo, `GH_PAT_FOR_WORKFLOW`.
+    *   Los nombres de los secretos son sensibles a mayúsculas y minúsculas y solo pueden contener caracteres alfanuméricos y guiones bajos.
+6.  **Value (Valor):**
+    *   Pega el valor del secreto (e.g., el Personal Access Token `ghp_...`).
+    *   **Importante:** Una vez guardado, no podrás volver a ver el valor del secreto desde la interfaz de GitHub, solo podrás actualizarlo o eliminarlo.
+7.  Haz clic en **Add secret**.
+
+Una vez guardado, el secreto está disponible para ser utilizado en tus workflows. Se accede a él usando la sintaxis `${{ secrets.NOMBRE_DEL_SECRETO }}`.
+
+**Ejemplo de uso en un workflow (hipotético):**
+```yaml
+name: Ejemplo Workflow con Secreto
+on: [push]
+jobs:
+  usar_secreto:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Realizar accion con PAT
+        run: |
+          echo "Llamando a una API con el PAT..."
+          curl -H "Authorization: token ${{ secrets.GH_PAT_FOR_WORKFLOW }}" https://api.github.com/user
+```
+
+### Nota sobre el workflow actual:
+En nuestro flujo de trabajo actual (`.github/workflows/main.yml`), el PAT que se utiliza para la autenticación de `gh` en la Raspberry Pi **no se gestiona como un secreto de GitHub Actions**. En su lugar, se configura directamente en la Raspberry Pi usando `gh auth login` para el usuario `github-runner`. Esto se debe a que la autenticación es persistente en la Pi para ese usuario específico.
+
+Si el workflow en sí (la parte que se ejecuta en `ubuntu-latest` antes del despliegue) necesitara interactuar con la API de GitHub por alguna razón, entonces sí usaríamos un secreto de GitHub Actions como se describió arriba.
+
+## Secretos en la Raspberry Pi (Autenticación de `gh`)
+
+El principal secreto que manejamos en la Raspberry Pi es el Personal Access Token utilizado para autenticar la herramienta `gh` (GitHub CLI). Esta autenticación permite al usuario `github-runner` interactuar con GitHub para tareas como clonar el repositorio, verificar el estado, etc. (aunque nuestro `deploy.sh` actual no usa `gh`).
+
+### Método Principal (`gh auth login`):
+Como se detalla en la guía `13-GitHub-CLI-Autenticacion.md`:
+
+1.  **Proceso:** El método preferido es iniciar sesión como el usuario `github-runner` (`sudo -iu github-runner`) y luego ejecutar `gh auth login`.
+2.  **Almacenamiento Seguro:** `gh` almacena el token de forma segura en un archivo de configuración dentro del directorio home del usuario: `/home/github-runner/.config/gh/hosts.yml`. Este archivo tiene permisos restrictivos (normalmente `600`), lo que significa que solo el usuario `github-runner` puede leerlo o escribirlo.
+3.  **Ventajas:**
+    *   El token no se expone directamente en scripts.
+    *   No se guarda en el historial de comandos de bash de forma persistente (solo durante el momento de pegarlo).
+    *   `gh` maneja el uso del token de forma transparente.
+
+### Alternativas (Menos recomendadas para `gh`, pero informativas):
+Aunque `gh auth login` es el método ideal para autenticar `gh`, es útil conocer otras formas en que los secretos (como los PATs) podrían manejarse si fueran necesarios para otros scripts o herramientas que no tienen un mecanismo de autenticación tan robusto.
+
+*   **Variables de Entorno:**
+    Si un script diferente a `gh` (por ejemplo, un script que usa `curl` para interactuar directamente con la API de GitHub, o `git clone` con HTTPS sin la ayuda de `gh`) necesitara un PAT, se podría configurar como una variable de entorno para el usuario `github-runner`.
+    *   **Ejemplo:**
+        Se podría añadir la siguiente línea al archivo `~/.bashrc` (o `~/.profile`) del usuario `github-runner`:
+        ```bash
+        export GITHUB_TOKEN="ghp_tuPATaqui12345"
+        ```
+        Luego, el script podría acceder a esta variable (`echo $GITHUB_TOKEN`).
+    *   **Precauciones:**
+        *   **Seguridad:** Este método es menos seguro. Si otros usuarios pueden leer el archivo `.bashrc` del usuario `github-runner`, o si las variables de entorno se registran en logs, el token podría quedar expuesto.
+        *   **Permisos:** El archivo `~/.bashrc` debería tener permisos restrictivos (e.g., `chmod 600 /home/github-runner/.bashrc`).
+        *   **Activación:** Las variables en `.bashrc` se cargan al iniciar una sesión de shell interactiva. Para servicios o scripts no interactivos, `.profile` o configuraciones específicas del servicio podrían ser más apropiadas.
+
+*   **Archivos de Configuración Protegidos:**
+    Un PAT podría guardarse en un archivo dedicado, y los scripts podrían leerlo desde allí.
+    *   **Ejemplo:**
+        Guardar el token en `/home/github-runner/.mi_pat_secreto`.
+        ```bash
+        echo "ghp_tuPATaqui12345" > /home/github-runner/.mi_pat_secreto
+        sudo chown github-runner:github-runner /home/github-runner/.mi_pat_secreto
+        sudo chmod 600 /home/github-runner/.mi_pat_secreto
+        ```
+        Un script luego leería este archivo: `TOKEN=$(cat /home/github-runner/.mi_pat_secreto)`.
+    *   **Precauciones:** Similar a las variables de entorno, la seguridad depende de los permisos del archivo y de cómo se accede a él.
+
+**Conclusión para este proyecto:**
+Para la autenticación de `gh` en la Raspberry Pi con el usuario `github-runner`, el método `gh auth login` es el más seguro y recomendado, y hace innecesarias estas alternativas para ese propósito específico.
+
+## Buenas Prácticas para Personal Access Tokens (PATs)
+
+Independientemente de dónde o cómo uses los PATs, seguir estas buenas prácticas es crucial para la seguridad:
+
+1.  **Principio de Menor Privilegio:**
+    *   Crea PATs solo con los **scopes (permisos) estrictamente necesarios** para la tarea que realizarán. No otorgues permisos de `admin:org` si solo necesitas leer repositorios.
+    *   Para el runner de GitHub Actions en la Raspberry Pi y el uso de `gh`, el scope `repo` (control total de repositorios privados) suele ser el más común. Si solo necesitas acceder a repositorios públicos, el scope `public_repo` podría ser suficiente. Si necesitas gestionar workflows vía API, añade el scope `workflow`.
+
+2.  **Expiración:**
+    *   **Establece siempre una fecha de expiración** para tus PATs. GitHub permite tokens que no expiran, pero esta es una práctica menos segura.
+    *   Cuanto más corta sea la vida útil de un token, menor será la ventana de oportunidad si se compromete.
+    *   Recuerda renovar los tokens antes de que expiren para evitar interrupciones del servicio.
+
+3.  **No Incrustar Tokens en el Código:**
+    *   **Nunca guardes PATs directamente en tu código fuente**, scripts, archivos de configuración no protegidos, o cualquier archivo que se suba a un repositorio Git (incluso si el repositorio es privado).
+
+4.  **Revocación Inmediata:**
+    *   Si sospechas que un PAT ha sido comprometido o expuesto, **revócalo inmediatamente**.
+    *   Puedes hacerlo desde la página de configuración de "Personal access tokens" en "Developer settings" en GitHub.
+
+5.  **Nombres Descriptivos:**
+    *   Cuando generes un PAT, asígnale un **nombre descriptivo** que te ayude a recordar dónde se utiliza y para qué propósito. Esto facilita la auditoría y la gestión de tus tokens. (e.g., "rpi-surviving-chernarus-runner-gh-auth").
+
+6.  **Auditoría Regular:**
+    *   Revisa periódicamente los PATs que has creado. Elimina aquellos que ya no sean necesarios.
+
+Siguiendo estas pautas, puedes reducir significativamente el riesgo asociado con el uso de Personal Access Tokens y mantener un entorno de CI/CD más seguro.

--- a/wiki/es/CI-CD-Guia-Hugo-RPi.md
+++ b/wiki/es/CI-CD-Guia-Hugo-RPi.md
@@ -1,0 +1,387 @@
+# Guía Completa: CI/CD para Desplegar un Sitio Hugo en Raspberry Pi con GitHub Actions y Runner Auto-Alojado
+
+## 1. Introducción
+
+*   **Objetivo de la guía:** Configurar un sistema de Integración Continua y Despliegue Continuo (CI/CD) para el repositorio `terrerovgh/surviving-chernarus` (un proyecto Hugo). El objetivo es lograr el despliegue automático del sitio web en una Raspberry Pi 5 (ejecutando Arch Linux) cada vez que se realice un `push` a la rama `main`.
+*   **Componentes clave:**
+    *   **GitHub Actions:** Para orquestar el proceso de build y deploy.
+    *   **Runner Auto-Alojado (Self-Hosted Runner):** Instalado en la Raspberry Pi para ejecutar los trabajos de despliegue en el entorno local.
+    *   **GitHub CLI (`gh`):** Para la autenticación y gestión de tareas relacionadas con GitHub en la Raspberry Pi.
+    *   **Nginx:** Como servidor web en la Raspberry Pi para servir el sitio Hugo.
+*   **Flujo general:**
+    1.  Un desarrollador realiza un `push` de cambios a la rama `main` del repositorio.
+    2.  GitHub Actions detecta el `push` y dispara el workflow definido.
+    3.  Un primer job (`build`) se ejecuta en un runner alojado por GitHub para compilar el sitio Hugo. El resultado (la carpeta `public/`) se sube como un artefacto.
+    4.  Un segundo job (`deploy`) se ejecuta en el runner auto-alojado en la Raspberry Pi.
+    5.  El runner auto-alojado descarga el artefacto (sitio compilado).
+    6.  Un script (`deploy.sh`) en la Raspberry Pi se encarga de mover los archivos del sitio al directorio raíz de Nginx, ajustar permisos y reiniciar Nginx.
+    7.  El sitio web `surviving-chernarus` se actualiza y sirve la nueva versión.
+
+## 2. Prerrequisitos Generales
+
+Antes de comenzar, asegúrate de contar con lo siguiente:
+
+*   **Cuenta de GitHub:** Necesaria para alojar el repositorio y utilizar GitHub Actions.
+*   **Repositorio `terrerovgh/surviving-chernarus`:** Este repositorio debe contener un proyecto Hugo funcional.
+*   **Raspberry Pi 5:** Con Arch Linux instalado, configurado con una conexión a internet estable y acceso SSH (recomendado).
+*   **Conocimientos básicos:** Es útil tener familiaridad con la línea de comandos de Linux, Git (control de versiones), y el funcionamiento básico de Hugo.
+
+## 3. Configuración del Workflow de GitHub Actions
+
+El corazón de nuestro sistema CI/CD es el archivo de workflow de GitHub Actions. Este archivo YAML define los eventos que disparan el workflow y los jobs que se ejecutarán.
+
+*   **Explicación del archivo `.github/workflows/main.yml`:**
+    Este archivo define el pipeline de CI/CD. Se activará con cada `push` a la rama `main`.
+*   **Propósito de los dos jobs (`build` y `deploy`):**
+    *   **`build`:** Este job se ejecuta en un entorno virtual proporcionado por GitHub (`ubuntu-latest`). Su responsabilidad es:
+        1.  Obtener el código del repositorio.
+        2.  Configurar el entorno de Hugo.
+        3.  Construir el sitio Hugo (generando la carpeta `public`).
+        4.  Empaquetar la carpeta `public` como un artefacto y subirlo para que esté disponible para el siguiente job.
+    *   **`deploy`:** Este job depende del éxito del job `build` y se ejecuta en nuestro runner auto-alojado (etiquetado como `self-hosted`) en la Raspberry Pi. Su responsabilidad es:
+        1.  Descargar el artefacto (la carpeta `public`) generado por el job `build`.
+        2.  Ejecutar el script `deploy.sh` para transferir los archivos del sitio al directorio de Nginx y reiniciar el servidor web.
+
+*   **Contenido de `.github/workflows/main.yml`:**
+
+```yaml
+# Workflow name
+name: CI/CD Hugo Site to Raspberry Pi
+
+# Triggers: This workflow runs on pushes to the main branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Build job: Builds the Hugo site using a GitHub-hosted runner
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Checkout the repository code
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true  # Checkout submodules if any (e.g., themes)
+
+      # Step 2: Setup Hugo
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.110.0' # Specify Hugo version
+          extended: true          # Use Hugo extended version
+
+      # Step 3: Build the Hugo site
+      - name: Build Hugo site
+        run: hugo --minify # Build the site and minify output
+
+      # Step 4: Upload the build artifact (the 'public' directory)
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: hugo-site-public # Name of the artifact
+          path: public          # Path to the directory to upload
+
+  # Deploy job: Deploys the built site to the self-hosted Raspberry Pi runner
+  deploy:
+    runs-on: self-hosted # This job runs on the self-hosted runner (Raspberry Pi)
+    needs: build         # This job depends on the successful completion of the 'build' job
+    steps:
+      # Step 1: Download the build artifact
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: hugo-site-public # Name of the artifact to download
+          path: ./downloaded-site # Destination path for the downloaded artifact
+
+      # Step 2: Deploy to Nginx (or other web server)
+      # This step assumes you have a 'deploy.sh' script in your repository root
+      # and that your self-hosted runner has permissions to execute it and
+      # place files in the web server's root directory.
+      - name: Deploy to Nginx
+        run: |
+          echo "Starting deployment..."
+          if [ -f ./deploy.sh ]; then
+            chmod +x ./deploy.sh
+            sh ./deploy.sh ./downloaded-site
+            echo "Deployment script executed."
+          else
+            echo "ERROR: deploy.sh not found!"
+            exit 1
+          fi
+        # Example of what deploy.sh might contain:
+        # #!/bin/bash
+        # # Check if source directory is provided
+        # if [ -z "$1" ]; then
+        #   echo "Usage: $0 <source_directory>"
+        #   exit 1
+        # fi
+        # SOURCE_DIR="$1"
+        # TARGET_DIR="/var/www/html" # Adjust to your Nginx web root
+        # echo "Cleaning target directory: $TARGET_DIR"
+        # sudo rm -rf "$TARGET_DIR"/*
+        # echo "Copying new site files from $SOURCE_DIR to $TARGET_DIR"
+        # sudo cp -r "$SOURCE_DIR"/* "$TARGET_DIR"/
+        # echo "Deployment finished."
+```
+
+*   **Instrucciones sobre dónde colocar este archivo en el repositorio:**
+    Crea un directorio llamado `.github` en la raíz de tu repositorio `terrerovgh/surviving-chernarus`. Dentro de `.github`, crea otro directorio llamado `workflows`. Guarda el contenido YAML anterior en un archivo llamado `main.yml` dentro de este directorio. La ruta completa será: `.github/workflows/main.yml`.
+
+## 4. Configuración del Runner Auto-Alojado en Raspberry Pi (Arch Linux)
+
+Esta sección es crucial ya que el runner auto-alojado es el puente entre GitHub Actions y tu Raspberry Pi.
+
+*   **Guía Detallada:** La configuración completa del runner auto-alojado, incluyendo la instalación del software, creación de un usuario dedicado, y configuración como servicio `systemd`, se encuentra en el siguiente documento:
+    *   **[12-Configuracion-Runner-Autoalojado.md](12-Configuracion-Runner-Autoalojado.md)**
+*   **Resumen:** Esta guía cubre:
+    *   Prerrequisitos de software en la Raspberry Pi (git, gh, nginx, etc.).
+    *   Creación de un usuario `github-runner` dedicado por seguridad.
+    *   Descarga, configuración y registro del software del runner de GitHub Actions en tu repositorio.
+    *   Configuración del runner para que se ejecute como un servicio `systemd`, asegurando que se inicie automáticamente y se mantenga en ejecución.
+
+## 5. Script de Despliegue en la Raspberry Pi (`deploy.sh`)
+
+Este script es ejecutado por el runner auto-alojado en la Raspberry Pi. Su función es tomar los archivos del sitio Hugo compilado (descargados como artefacto) y desplegarlos en el servidor web Nginx.
+
+*   **Explicación del propósito del script `deploy.sh`:**
+    El script automatiza las siguientes tareas en la Raspberry Pi:
+    1.  Recibe la ruta del artefacto descargado (que contiene el sitio Hugo compilado).
+    2.  Crea el directorio raíz web de Nginx si no existe.
+    3.  Utiliza `rsync` para sincronizar eficientemente el contenido del artefacto con el directorio raíz web, eliminando archivos antiguos del destino que no estén en la fuente.
+    4.  Establece los permisos de archivo y propietario correctos (usuario `http`, grupo `http` para Nginx en Arch Linux) para los archivos del sitio.
+    5.  Reinicia el servicio Nginx para que los cambios surtan efecto.
+*   **Contenido de `deploy.sh`:**
+
+```bash
+#!/bin/bash
+
+# --- Error Handling ---
+# Exit immediately if a command exits with a non-zero status.
+set -e
+# Cause a pipeline to return the exit status of the last command in the pipe that failed.
+set -o pipefail
+
+# --- Script Configuration ---
+# NGINX_WEB_ROOT: The directory where Nginx serves files for this site.
+# This path is standard for user-deployed sites on Arch Linux (under /srv/http/).
+# IMPORTANT:
+# 1. This directory will be created by the script if it doesn't exist.
+# 2. The 'github-runner' user (or the user executing this script) needs sudo privileges
+#    to create this directory, run rsync with delete, chown, chmod, and restart nginx.
+NGINX_WEB_ROOT="/srv/http/surviving-chernarus"
+
+# --- Input Parameter Validation ---
+# Check if the path to the downloaded artifact is provided as the first argument.
+if [ -z "$1" ]; then
+  echo "Error: No artifact path provided."
+  echo "Usage: $0 <path_to_artifact>"
+  exit 1
+fi
+
+# Store the artifact path from the first argument.
+ARTIFACT_PATH="$1"
+echo "Artifact path: $ARTIFACT_PATH"
+
+# --- Deployment Steps ---
+echo "Starting deployment to Nginx web root: $NGINX_WEB_ROOT ..."
+
+# 1. Create Nginx web root directory if it doesn't exist.
+#    The -p flag ensures that parent directories are also created if needed,
+#    and it doesn't error if the directory already exists.
+echo "Ensuring Nginx web root directory exists: $NGINX_WEB_ROOT"
+sudo mkdir -p "$NGINX_WEB_ROOT"
+
+# 2. Clear existing content from Nginx web root and copy new site files.
+#    Using rsync with --delete is an efficient way to synchronize the content.
+#    The source path "$ARTIFACT_PATH/" (with a trailing slash) means "copy the contents
+#    of ARTIFACT_PATH".
+#    The destination path "$NGINX_WEB_ROOT/" ensures files are placed directly into it.
+#    --delete will remove any files in $NGINX_WEB_ROOT that are not in $ARTIFACT_PATH.
+echo "Clearing old content and copying new site files from $ARTIFACT_PATH to $NGINX_WEB_ROOT ..."
+sudo rsync -a --delete "$ARTIFACT_PATH/" "$NGINX_WEB_ROOT/"
+
+# 3. Set appropriate permissions for the web files.
+#    This is crucial for security and for Nginx to be able to read the files.
+#    On Arch Linux, Nginx typically runs as the 'http' user and group.
+echo "Setting permissions for $NGINX_WEB_ROOT ..."
+# Set ownership to http:http
+sudo chown -R http:http "$NGINX_WEB_ROOT"
+# Set directory permissions to 755 (rwxr-xr-x)
+sudo find "$NGINX_WEB_ROOT" -type d -exec chmod 755 {} \;
+# Set file permissions to 644 (rw-r--r--)
+sudo find "$NGINX_WEB_ROOT" -type f -exec chmod 644 {} \;
+
+# 4. Restart Nginx to apply changes.
+#    This ensures that Nginx serves the new files.
+echo "Restarting Nginx service ..."
+sudo systemctl restart nginx
+
+echo "-------------------------------------"
+echo "Deployment completed successfully!"
+echo "Site deployed to: $NGINX_WEB_ROOT"
+echo "-------------------------------------"
+
+exit 0
+```
+
+*   **Instrucciones sobre dónde colocar este script en el repositorio y cómo hacerlo ejecutable:**
+    1.  Guarda el contenido del script en un archivo llamado `deploy.sh` en la **raíz de tu repositorio** `terrerovgh/surviving-chernarus`.
+    2.  Hazlo ejecutable:
+        ```bash
+        git add deploy.sh
+        git update-index --chmod=+x deploy.sh
+        git commit -m "Add deploy script and make it executable"
+        git push
+        ```
+        Alternativamente, puedes ejecutar `chmod +x deploy.sh` en tu entorno local antes de hacer `git add` y `git commit`. `git update-index --chmod=+x` es útil si el archivo ya está trackeado.
+
+*   **Importante: Configuración de `sudo` para el runner:**
+    El usuario `github-runner` (bajo el cual se ejecuta el servicio del runner en la Raspberry Pi) necesita permisos para ejecutar los comandos con `sudo` que se encuentran dentro de `deploy.sh` (específicamente `mkdir`, `rsync`, `chown`, `find`, y `systemctl`).
+    La forma recomendada de configurar esto es editando el archivo `sudoers` en la Raspberry Pi.
+
+    **Usa `sudo visudo` para editar el archivo `sudoers`. Nunca edites `sudoers` directamente con un editor de texto normal.**
+
+    *   **Opción 1: Permitir `NOPASSWD` para comandos específicos (Más Seguro):**
+        Esta es la opción preferida porque limita los comandos que `github-runner` puede ejecutar sin contraseña.
+        Añade las siguientes líneas al final del archivo `sudoers` (usando `sudo visudo`):
+        ```
+        # Allow github-runner to execute specific deployment commands without a password
+        Cmnd_Alias DEPLOY_COMMANDS = /usr/bin/mkdir, /usr/bin/rsync, /usr/bin/chown, /usr/bin/find, /usr/bin/systemctl restart nginx
+        github-runner ALL=(ALL) NOPASSWD: DEPLOY_COMMANDS
+        ```
+        *Nota: Para `chown` y `find`, podrías ser aún más específico con los argumentos si fuera necesario, pero esto proporciona un buen balance entre seguridad y funcionalidad.*
+
+    *   **Opción 2: Permitir `NOPASSWD` para el script completo (Menos Seguro):**
+        Si eliges esta opción, asegúrate de que el script `deploy.sh` no sea modificable por usuarios no autorizados. La ruta al script puede ser un poco dinámica debido a cómo GitHub Actions clona el repositorio en el directorio de trabajo del runner (e.g., `/home/github-runner/actions-runner/_work/surviving-chernarus/surviving-chernarus/deploy.sh`). Debido a esta ruta dinámica, la Opción 1 (comandos específicos) es generalmente más robusta y segura.
+        Si aun así deseas usar esta opción, y asumiendo que el script se encuentra en una ruta predecible que el runner utiliza, podrías añadir:
+        `github-runner ALL=(ALL) NOPASSWD: /ruta/absoluta/al/deploy.sh`
+        **Advertencia:** Esta opción es menos segura porque si el script `deploy.sh` es comprometido y modificado para incluir comandos maliciosos, estos se ejecutarán con `sudo` sin contraseña.
+
+## 6. Uso y Autenticación de GitHub CLI (`gh`) en la Raspberry Pi
+
+La herramienta `gh` es esencial para que el runner auto-alojado se autentique con GitHub y para diversas tareas de administración y diagnóstico.
+
+*   **Guía Detallada:** Las instrucciones completas para instalar y autenticar `gh` para el usuario `github-runner` en tu Raspberry Pi se encuentran aquí:
+    *   **[13-GitHub-CLI-Autenticacion.md](13-GitHub-CLI-Autenticacion.md)**
+*   **Resumen:** Este documento explica:
+    *   Cómo instalar `gh` en Arch Linux.
+    *   El proceso paso a paso para autenticar `gh` usando un Personal Access Token (PAT), asegurando que el usuario `github-runner` pueda interactuar con tu repositorio.
+    *   Cómo `gh` almacena de forma segura el token.
+
+## 7. Gestión de Secretos (Personal Access Tokens - PAT)
+
+El manejo adecuado de los Personal Access Tokens (PATs) es vital para la seguridad de tu configuración.
+
+*   **Guía Detallada:** Aprende sobre la gestión de PATs tanto en GitHub Actions como en la configuración local de `gh` en la Raspberry Pi:
+    *   **[14-Gestion-Secretos.md](14-Gestion-Secretos.md)**
+*   **Resumen:** Este documento cubre:
+    *   Cómo configurar secretos a nivel de repositorio en GitHub Actions (aunque no se usan directamente para la autenticación del runner en este flujo específico).
+    *   Cómo el PAT para `gh` se maneja de forma segura en la Raspberry Pi.
+    *   Buenas prácticas cruciales para la creación, uso y gestión de PATs (principio de menor privilegio, expiración, no incrustar tokens en código, etc.).
+
+## 8. Configuración de Nginx
+
+Nginx es el servidor web que mostrará tu sitio Hugo al mundo. Aquí se asume que ya tienes Nginx instalado (cubierto en los prerrequisitos de la guía del runner).
+
+*   **Directorio Raíz Web:** El script `deploy.sh` está configurado para desplegar los archivos del sitio en `/srv/http/surviving-chernarus`.
+*   **Archivo de Configuración del Sitio (Virtual Host):**
+    Crea un archivo de configuración para tu sitio en Nginx. Por ejemplo, `/etc/nginx/sites-available/surviving-chernarus.conf`:
+    ```bash
+    sudo nano /etc/nginx/sites-available/surviving-chernarus.conf
+    ```
+    Pega la siguiente configuración, **ajustando `server_name`** a la dirección IP de tu Raspberry Pi o a tu nombre de dominio si tienes uno configurado:
+
+    ```nginx
+    server {
+        listen 80;
+        # Cambia 'tu_dominio_o_ip_de_rpi' por la IP de tu Raspberry Pi
+        # o tu nombre de dominio si lo tienes.
+        server_name tu_dominio_o_ip_de_rpi;
+
+        # Directorio raíz donde se encuentran los archivos de tu sitio Hugo
+        root /srv/http/surviving-chernarus;
+        index index.html index.htm;
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+
+        # Opcional: Configuraciones de logs
+        access_log /var/log/nginx/surviving-chernarus.access.log;
+        error_log /var/log/nginx/surviving-chernarus.error.log;
+
+        # Opcional: Para mejorar la entrega de assets estáticos
+        location ~* \.(?:css|js|jpg|jpeg|gif|png|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1M; # Cache de 1 mes para assets estáticos
+            add_header Cache-Control "public";
+        }
+    }
+    ```
+
+*   **Habilitar el Sitio y Probar Configuración:**
+    1.  Crea un enlace simbólico desde `sites-available` a `sites-enabled` para activar la configuración:
+        ```bash
+        sudo ln -s /etc/nginx/sites-available/surviving-chernarus.conf /etc/nginx/sites-enabled/surviving-chernarus.conf
+        ```
+        (Si el archivo ya existe en `sites-enabled` porque es la configuración por defecto, este paso podría no ser necesario o podrías estar editando el archivo por defecto directamente).
+    2.  Prueba la configuración de Nginx para asegurarte de que no hay errores de sintaxis:
+        ```bash
+        sudo nginx -t
+        ```
+        Si muestra "syntax is ok" y "test is successful", todo está bien.
+    3.  Recarga o reinicia Nginx para aplicar los cambios (el script `deploy.sh` ya incluye un reinicio, pero si haces cambios manuales en la configuración de Nginx, necesitarás recargarlo):
+        ```bash
+        sudo systemctl reload nginx
+        ```
+        o
+        ```bash
+        sudo systemctl restart nginx
+        ```
+
+## 9. Puesta en Marcha y Pruebas
+
+Con todos los componentes configurados, es hora de poner en marcha el sistema y probarlo.
+
+*   **Resumen de los pasos para activar todo:**
+    1.  Asegúrate de que el archivo de workflow `.github/workflows/main.yml` y el script `deploy.sh` están en tu repositorio (`terrerovgh/surviving-chernarus`) y que los cambios han sido subidos a GitHub (`git push`).
+    2.  Verifica que el runner auto-alojado está configurado, en línea y escuchando trabajos en tu Raspberry Pi (revisa el estado del servicio `systemd` y la sección "Runners" en la configuración de tu repositorio en GitHub).
+    3.  Confirma que `gh` está autenticado para el usuario `github-runner` en la Raspberry Pi.
+    4.  Revisa que Nginx esté configurado con el virtual host para servir el sitio desde `/srv/http/surviving-chernarus` y que el servicio Nginx esté corriendo.
+    5.  Asegúrate de que los permisos de `sudo` para el usuario `github-runner` (para ejecutar los comandos en `deploy.sh`) estén correctamente configurados en el archivo `sudoers` de la Raspberry Pi.
+
+*   **Cómo probar:**
+    1.  Realiza un cambio en tu sitio Hugo (e.g., modifica un archivo de contenido, crea un nuevo post).
+    2.  Haz `commit` de los cambios y luego `push` a la rama `main` de tu repositorio en GitHub.
+        ```bash
+        git add .
+        git commit -m "Prueba de despliegue CI/CD"
+        git push origin main
+        ```
+    3.  Observa el workflow en la pestaña "Actions" de tu repositorio en GitHub. Deberías ver el workflow dispararse.
+    4.  Sigue el progreso del job `build`. Una vez completado, sigue el progreso del job `deploy`.
+    5.  Si todo va bien, el job `deploy` debería finalizar con éxito.
+    6.  Abre un navegador web y accede a la dirección de tu Raspberry Pi (la que configuraste en `server_name` en Nginx). Deberías ver tu sitio Hugo actualizado.
+
+*   **Troubleshooting básico (Solución de problemas):**
+    *   **Logs de GitHub Actions:** Revisa la salida de cada paso en los jobs `build` y `deploy` directamente en la interfaz de GitHub Actions. Aquí encontrarás errores de compilación de Hugo, problemas de descarga/subida de artefactos, o errores del script `deploy.sh`.
+    *   **Logs del Runner en la Raspberry Pi:** Los logs del servicio del runner pueden proporcionar información si el runner no se conecta o no recoge trabajos. Usa `journalctl -u NOMBRE_DEL_SERVICIO_DEL_RUNNER -f` (reemplaza con el nombre real de tu servicio de runner). También puedes encontrar logs más detallados dentro del directorio de instalación del runner en la carpeta `_diag`.
+    *   **Logs de Nginx en la Raspberry Pi:**
+        *   `access_log` (`/var/log/nginx/surviving-chernarus.access.log` o el general `/var/log/nginx/access.log`): Muestra las peticiones HTTP recibidas por Nginx.
+        *   `error_log` (`/var/log/nginx/surviving-chernarus.error.log` o el general `/var/log/nginx/error.log`): Registra errores de Nginx, como problemas de permisos de archivo, errores de configuración, etc.
+    *   **Verificar permisos de `sudo`:** Si el `deploy.sh` falla en la Raspberry Pi, asegúrate de que los permisos en `sudoers` son correctos y que el usuario `github-runner` puede ejecutar los comandos necesarios.
+
+## 10. Conclusión
+
+¡Felicidades! Si has seguido esta guía, ahora tienes un sistema de CI/CD completamente funcional que compila tu sitio Hugo y lo despliega automáticamente en tu Raspberry Pi cada vez que haces un push a tu rama `main`. Esta configuración te ahorra el trabajo manual de compilación y despliegue, permitiéndote enfocarte en crear contenido para tu sitio.
+
+*   **Posibles mejoras futuras:**
+    *   **Notificaciones:** Configurar notificaciones (e.g., por email o Slack) sobre el estado de los workflows (éxito o fallo).
+    *   **Manejo de Fallos Avanzado:** Implementar estrategias de rollback o alertas más detalladas si un despliegue falla.
+    *   **Pruebas Automatizadas:** Añadir un paso de pruebas (e.g., `hugo server -D` y luego `curl` para verificar que el sitio se construye correctamente, o pruebas de enlaces rotos) en el job `build`.
+    *   **Seguridad Avanzada:** Implementar HTTPS usando Let's Encrypt para tu sitio Nginx.
+    *   **Optimización de la Build:** Para sitios muy grandes, explorar estrategias de caché de Hugo o de dependencias para acelerar el job `build`.
+
+Esta guía proporciona una base sólida. ¡Siéntete libre de adaptarla y expandirla según tus necesidades!
+```


### PR DESCRIPTION
…/workflow configurations for setting up a CI/CD pipeline. The pipeline automates the deployment of a Hugo website from the `terrerovgh/surviving-chernarus` repository to a Raspberry Pi (Arch Linux) using GitHub Actions and a self-hosted runner.

The documentation is in Spanish and located under the `wiki/es/` directory, with `CI-CD-Guia-Hugo-RPi.md` as the main entry point. It covers:
- GitHub Actions workflow design (`main.yml`).
- Self-hosted runner setup on Arch Linux, including systemd service.
- A `deploy.sh` script for updating the Nginx web server.
- GitHub CLI (`gh`) authentication on the Raspberry Pi.
- Secure management of Personal Access Tokens (PATs).
- Nginx configuration for serving the Hugo site.
- `sudo` configuration for the runner user.

The actual `main.yml` and `deploy.sh` files should be created by you in your repository based on the content provided in the guide.