### PR TITLE
feat: Migrate to nftables, add Cloudflare DDNS & centralized config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Wi-Fi Hotspot (Edit hostapd.conf directly, use these as reference)
+# WIFI_SSID="YourHotspotSSID"
+# WIFI_PASSWORD="YourStrongPassword"
+# WIFI_COUNTRY_CODE="US"
+
+# Pi-hole Docker Container
+PIHOLE_WEBPASSWORD="YourPiholeAdminPassword" # For the Dockerized Pi-hole's web UI
+TZ="America/Chicago" # Timezone for Dockerized Pi-hole
+
+# Cloudflare DDNS Script
+CLOUDFLARE_API_TOKEN="YourCloudflareAPIToken"
+CLOUDFLARE_ZONE_NAME="terrerov.com" # Your domain name
+CLOUDFLARE_RECORD_NAME="rpi.terrerov.com" # The A record to update (e.g., rpi.yourdomain.com)
+
+# Add any other relevant variables that might emerge

--- a/GUIDANCE_AND_EXPLANATIONS.md
+++ b/GUIDANCE_AND_EXPLANATIONS.md
@@ -6,7 +6,8 @@ This guide provides instructions for setting up a Wi-Fi hotspot named `rpi` (int
 
 1.  **`hotspot_config/hostapd.conf`**: Configuration for `hostapd`, the software that creates the wireless access point.
 2.  **`hotspot_config/pihole_custom_dnsmasq.conf`**: DHCP configuration for `dnsmasq` (managed by Pi-hole) to assign IP addresses to devices connecting to the hotspot.
-3.  **`scripts/setup_hotspot_nat.sh`**: A shell script to configure Network Address Translation (NAT) and IP forwarding, allowing hotspot clients to access the internet through the Raspberry Pi's other network connection (e.g., `eth0`).
+3.  **`hotspot_config/dnsmasq_custom/03-terrerov-domain.conf`**: Custom dnsmasq configuration for resolving `*.terrerov.com` locally.
+4.  **`scripts/setup_hotspot_nat_nft.sh`**: A shell script using `nftables` to configure Network Address Translation (NAT) and IP forwarding, allowing hotspot clients to access the internet through the Raspberry Pi's other network connection (e.g., `eth0`).
 
 ## I. `hostapd` Configuration (Access Point Setup)
 
@@ -60,28 +61,44 @@ The `hotspot_config/hostapd.conf` file configures the basic parameters of your W
 
 ## II. DHCP Server Configuration (via Pi-hole/dnsmasq)
 
+**Prerequisite: Pi-hole Installation**
+
+This guide assumes you have already installed Pi-hole on your Raspberry Pi host system. If not, install it first using the official command:
+```bash
+curl -sSL https://install.pi-hole.net | bash
+```
+Follow the on-screen prompts during the Pi-hole installation. When asked about the interface, you can select your primary Ethernet interface (e.g., `eth0`). The custom configurations below will enable Pi-hole to also serve DHCP/DNS for the `wlan0` hotspot.
+
 **DHCP Choice Explanation:**
 
 For thematic consistency with `StarySobor_RadioPost` (your Pi-hole instance) and to centralize DNS and IP management, these instructions integrate DHCP services for the hotspot directly into Pi-hole. Pi-hole uses `dnsmasq` internally, which is a lightweight DHCP and DNS caching server. By adding a custom configuration file to Pi-hole's `dnsmasq` setup, we can make Pi-hole responsible for assigning IP addresses to devices connecting to the `Chernarus_Beacon` hotspot (`wlan0`). This avoids running a separate DHCP server and ensures that hotspot clients can easily use Pi-hole for DNS.
 
-**Deployment Steps for `pihole_custom_dnsmasq.conf`:**
+**Deployment Steps for DHCP & Custom DNS:**
 
-1.  **Copy the Custom `dnsmasq` Configuration:**
-    Place the generated `hotspot_config/pihole_custom_dnsmasq.conf` file into the `/etc/dnsmasq.d/` directory on your Raspberry Pi (the one running Pi-hole). It's good practice to give it a descriptive name, for example:
+1.  **Copy the Custom DHCP `dnsmasq` Configuration:**
+    This file (`pihole_custom_dnsmasq.conf`) configures DHCP for the hotspot.
+    Place the `hotspot_config/pihole_custom_dnsmasq.conf` file into the `/etc/dnsmasq.d/` directory on your Raspberry Pi.
     ```bash
     sudo cp hotspot_config/pihole_custom_dnsmasq.conf /etc/dnsmasq.d/02-chernarus-hotspot-dhcp.conf
     ```
     (The `02-` prefix helps with ordering if you have multiple custom files).
 
-2.  **Restart Pi-hole's FTLDNS Service:**
-    This will make `dnsmasq` pick up the new configuration.
+2.  **Copy the Custom `*.terrerov.com` Domain Resolution Configuration:**
+    This file (`03-terrerov-domain.conf`) makes any domain ending in `.terrerov.com` resolve to `192.168.73.1`.
+    Place the `hotspot_config/dnsmasq_custom/03-terrerov-domain.conf` file into the `/etc/dnsmasq.d/` directory.
+    ```bash
+    sudo cp hotspot_config/dnsmasq_custom/03-terrerov-domain.conf /etc/dnsmasq.d/03-terrerov-domain.conf
+    ```
+
+3.  **Restart Pi-hole's FTLDNS Service:**
+    This will make `dnsmasq` pick up the new configurations.
     ```bash
     sudo pihole restartdns
     # OR, if the above command is not found or you prefer systemctl:
     # sudo systemctl restart pihole-FTL.service
     ```
 
-3.  **Pi-hole `setupVars.conf` Check (Important):**
+4.  **Pi-hole `setupVars.conf` Check (Important):**
     Ensure Pi-hole's main configuration (`/etc/pihole/setupVars.conf`) does **not** define `PIHOLE_INTERFACE` in a way that would conflict. For example, if `PIHOLE_INTERFACE` is set strictly to `eth0`, Pi-hole might not listen for DHCP requests on `wlan0` even with the custom config.
     *   The `interface=wlan0` line within your `02-chernarus-hotspot-dhcp.conf` is intended to explicitly tell `dnsmasq` to listen on `wlan0` for DHCP (and DNS) queries for the hotspot.
     *   If you have `PIHOLE_INTERFACE` set in `setupVars.conf`, and it's *not* set to listen on all interfaces (e.g., `PIHOLE_INTERFACE=`), you might need to remove that specific line or adjust it if issues arise. Often, for Pi-hole to serve DHCP on multiple interfaces, it's best to let `dnsmasq.d` configurations handle the interface specifics.
@@ -126,39 +143,42 @@ Most Raspberry Pi OS versions use `dhcpcd` to manage network interfaces.
     ```
     Verify with `ip addr show wlan0` that it has the IP `192.168.73.1`.
 
-**NAT and IP Forwarding (`scripts/setup_hotspot_nat.sh`):**
+**NAT and IP Forwarding with `nftables` (`scripts/setup_hotspot_nat_nft.sh`):**
 
-This script enables the Raspberry Pi to act as a router, forwarding traffic from the Wi-Fi hotspot clients (`wlan0`) to your main internet connection (assumed to be `eth0`).
+This script enables the Raspberry Pi to act as a router, forwarding traffic from the Wi-Fi hotspot clients (`wlan0`) to your main internet connection (e.g., `eth0`), using `nftables`. **This script initializes the entire `nftables` ruleset, potentially flushing any pre-existing rules.** It's designed to be the first firewall script you run.
 
-1.  **Review Internet Interface:**
-    The script defaults to using `eth0` as the internet-connected interface (`ETH_IF="eth0"`). If your Raspberry Pi gets its internet connection from a different interface (e.g., `usb0`, or another Wi-Fi adapter like `wlan1`), **you must edit `scripts/setup_hotspot_nat.sh` and change the `ETH_IF` variable** to match your setup.
+1.  **Review Interface Variables:**
+    Open `scripts/setup_hotspot_nat_nft.sh` with a text editor.
+    *   Verify `ETH_IF="eth0"`: This variable should match your Raspberry Pi's internet-connected interface (e.g., `eth0`, `usb0`).
+    *   Verify `WLAN_IF="wlan0"`: This should match your hotspot interface.
+    *   Verify `HOTSPOT_NET="192.168.73.0/24"`: This should match your hotspot network.
+    **You must edit these variables in the script if your setup differs.**
 
 2.  **Make the Script Executable:**
     Navigate to the directory where you cloned the repository.
     ```bash
-    chmod +x scripts/setup_hotspot_nat.sh
+    chmod +x scripts/setup_hotspot_nat_nft.sh
     ```
 
 3.  **Run the Script:**
     Execute the script with superuser privileges:
     ```bash
-    sudo ./scripts/setup_hotspot_nat.sh
+    sudo ./scripts/setup_hotspot_nat_nft.sh
     ```
-    This will enable IP forwarding and set up the necessary `iptables` rules. The script includes rules to allow DHCP and DNS traffic to the Pi itself on `wlan0`, which are needed for Pi-hole/dnsmasq to function for hotspot clients.
+    This will enable IP forwarding and set up the necessary `nftables` rules. The script includes rules to allow DHCP and DNS traffic to the Pi itself on `wlan0`, which are needed for Pi-hole/dnsmasq to function for hotspot clients.
 
-4.  **Make Firewall Rules Persistent:**
-    The `iptables` rules set by the script are temporary and will be lost on reboot. To make them persistent:
-    *   Install `iptables-persistent`:
+4.  **Firewall Rule Persistence (`nftables`):**
+    The `nftables` rules applied by this script are temporary and will be lost on reboot unless saved.
+    *   **Ensure `nftables` is installed and enabled:** The main `README.md` covers installing `nftables`. Enable the service if not already:
         ```bash
-        sudo apt-get update && sudo apt-get install -y iptables-persistent
+        sudo systemctl enable nftables.service
         ```
-    *   During the installation, you will be asked if you want to save current IPv4 and IPv6 rules. Answer **Yes** for IPv4. You can answer No for IPv6 if you are not using it.
-    *   If you modify the firewall rules later (e.g., by re-running the `setup_hotspot_nat.sh` script or making manual changes), you must save them again:
+    *   **Saving Rules:** After running this script (and any other `nftables` scripts like those for captive portal or Squid redirection, in the correct order), and verifying everything works, save the complete ruleset:
         ```bash
-        sudo netfilter-persistent save
-        # Alternatively, reconfigure the package:
-        # sudo dpkg-reconfigure iptables-persistent
+        sudo nft list ruleset > /etc/nftables.conf
         ```
+        This command overwrites the default `nftables.conf` file. If you have other `nftables` rules you wish to preserve, you'll need to merge them manually.
+    *   The `nftables.service` will automatically load `/etc/nftables.conf` on boot.
 
 ## IV. Starting and Testing the Hotspot
 
@@ -197,12 +217,15 @@ This script enables the Raspberry Pi to act as a router, forwarding traffic from
     *   Ensure `wlan0` is not already in use or configured in client mode by other networking services (e.g. NetworkManager or wpa_supplicant if not properly configured for AP mode). The `nohook wpa_supplicant` line in `dhcpcd.conf` for `wlan0` can help prevent conflicts.
     *   Verify the `country_code` in `hostapd.conf` is valid.
 *   **No IP address on client devices**:
-    *   Ensure `pihole-FTL.service` (dnsmasq) is running and configured correctly for `wlan0`. Check `/var/log/pihole-FTL.log` or `/var/log/daemon.log` / `/var/log/syslog` for dnsmasq errors.
-    *   Verify the `iptables` rules for DHCP (port 67) are present (`sudo iptables -L INPUT -v -n --line-numbers`).
+    *   Ensure `pihole-FTL.service` (dnsmasq) is running and configured correctly for `wlan0` (as per Section II). Check `/var/log/pihole-FTL.log` or `/var/log/daemon.log` / `/var/log/syslog` for dnsmasq errors.
+    *   Verify the `nftables` rules allow DHCP: Run `sudo nft list ruleset`. Look for rules in the `input` chain of the `firewall_table` (or similar, as defined in `setup_hotspot_nat_nft.sh`) that accept UDP traffic on port 67 for the `wlan0` interface (e.g., `iifname "wlan0" udp dport 67 accept`).
 *   **No internet on client devices**:
-    *   Double-check the `ETH_IF` variable in `setup_hotspot_nat.sh` matches your actual internet-providing interface.
-    *   Ensure IP forwarding is enabled: `cat /proc/sys/net/ipv4/ip_forward` (should be `1`).
-    *   Verify the `iptables` NAT and FORWARD rules: `sudo iptables -t nat -L -v -n --line-numbers` and `sudo iptables -L FORWARD -v -n --line-numbers`.
-    *   Check DNS settings on the client – it should be `192.168.73.1`.
+    *   Double-check the `ETH_IF` and `WLAN_IF` variables in `scripts/setup_hotspot_nat_nft.sh` match your actual interfaces.
+    *   Ensure IP forwarding is enabled: `cat /proc/sys/net/ipv4/ip_forward` (should be `1`). The `setup_hotspot_nat_nft.sh` script should enable this.
+    *   Verify the `nftables` NAT and FORWARD rules:
+        *   Run `sudo nft list ruleset`.
+        *   Check the `postrouting` chain in the `nat_table` (or similar, as defined in `setup_hotspot_nat_nft.sh`) for a masquerade rule for your hotspot network (e.g., `ip saddr 192.168.73.0/24 oifname "eth0" masquerade`).
+        *   Check the `forward` chain in the `firewall_table` (or similar) for rules allowing traffic from `wlan0` to `eth0` and established/related traffic back.
+    *   Check DNS settings on the client – it should be `192.168.73.1`. Ensure Pi-hole is functioning and resolving external domains.
 
 This completes the setup for your Chernarus_Beacon Wi-Fi hotspot!

--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ This README provides a consolidated overview and deployment plan. Detailed setup
 **Hotspot Configuration (`Chernarus_Beacon`):**
 *   `hotspot_config/hostapd.conf` (Wi-Fi AP configuration)
 *   `hotspot_config/pihole_custom_dnsmasq.conf` (DHCP configuration for Pi-hole/dnsmasq)
-*   `scripts/setup_hotspot_nat.sh` (NAT and forwarding script for basic internet access)
+*   `scripts/setup_hotspot_nat_nft.sh` (nftables script for NAT and forwarding)
 *   `GUIDANCE_AND_EXPLANATIONS.md` (Detailed setup guide for the hotspot component)
 
 **Squid Proxy (`Berezino_Checkpoint`):**
 *   `squid_Berezino_Checkpoint/docker-compose.yml` (Docker Compose for Squid)
 *   `squid_Berezino_Checkpoint/squid.conf` (Squid proxy configuration)
 *   `squid_Berezino_Checkpoint/certs/.gitkeep` (Placeholder for SSL CA certificate - **user must add `myCA.pem` here**)
-*   `scripts/redirect_to_squid.sh` (iptables script to redirect traffic to Squid)
+*   `scripts/redirect_to_squid_nft.sh` (nftables script to redirect traffic to Squid)
 *   `squid_Berezino_Checkpoint/README_SQUID.md` (Detailed setup guide for the Squid proxy component)
 
 **Captive Portal (`Chernarus_Entrypoint`):**
 *   `captive_portal_Chernarus_Entrypoint/docker-compose.yml` (Docker Compose for Nginx portal)
 *   `captive_portal_Chernarus_Entrypoint/html/index.html` (Portal page for CA certificate download)
 *   `captive_portal_Chernarus_Entrypoint/html/.gitkeep` (Ensures `html` directory for `index.html` and CA cert - **user must add CA cert (e.g., `myCA.pem` or `.crt`) here for download**)
-*   `scripts/setup_captive_portal_redirect.sh` (iptables script to redirect users to portal)
+*   `scripts/setup_captive_portal_redirect_nft.sh` (nftables script to redirect users to portal)
 *   `captive_portal_Chernarus_Entrypoint/README_PORTAL.md` (Detailed setup guide for the captive portal component)
 
 **Repository Structure Overview:**
@@ -38,7 +38,9 @@ This README provides a consolidated overview and deployment plan. Detailed setup
 surviving-chernarus/
 ├── hotspot_config/
 │   ├── hostapd.conf
-│   └── pihole_custom_dnsmasq.conf
+│   ├── pihole_custom_dnsmasq.conf
+│   └── dnsmasq_custom/
+│       └── 03-terrerov-domain.conf
 ├── squid_Berezino_Checkpoint/
 │   ├── certs/
 │   │   └── .gitkeep
@@ -52,14 +54,53 @@ surviving-chernarus/
 │   │   └── index.html
 │   └── README_PORTAL.md
 ├── scripts/
-│   ├── redirect_to_squid.sh
-│   ├── setup_captive_portal_redirect.sh
-│   └── setup_hotspot_nat.sh
+│   ├── cloudflare_ddns.py
+│   ├── redirect_to_squid_nft.sh
+│   ├── setup_captive_portal_redirect_nft.sh
+│   └── setup_hotspot_nat_nft.sh
+├── .env.example
 ├── GUIDANCE_AND_EXPLANATIONS.md
 └── README.md  # This file
 ```
 
-## II. Deployment and Execution Summary
+## II. Centralized Configuration (.env file)
+
+This project uses a `.env` file at its root to manage sensitive and environment-specific configurations. This file is NOT committed to the repository (and should be listed in your `.gitignore` file).
+
+**Setup:**
+
+1.  Copy the example configuration file to `.env`:
+    ```bash
+    cp .env.example .env
+    ```
+2.  **Edit `.env`** with your specific values.
+3.  **IMPORTANT**: Add `.env` to your project's `.gitignore` file to prevent accidentally committing your secrets:
+    ```bash
+    echo '.env' >> .gitignore
+    ```
+
+**Variables to Configure in `.env`:**
+
+*   `PIHOLE_WEBPASSWORD`: Sets the admin password for the Dockerized Pi-hole web interface.
+*   `TZ`: Sets the timezone for the Dockerized Pi-hole container (e.g., `America/Chicago`).
+*   `CLOUDFLARE_API_TOKEN`: Your API Token for Cloudflare, used by the DDNS script. (Permissions: Zone.DNS:Edit for the specified zone).
+*   `CLOUDFLARE_ZONE_NAME`: The domain name (zone) you manage in Cloudflare (e.g., `terrerov.com`).
+*   `CLOUDFLARE_RECORD_NAME`: The specific 'A' record to update with your RPi's public IP (e.g., `rpi.terrerov.com`).
+
+**Reference Variables (Manual Configuration):**
+
+The following variables are commented out in `.env.example` but can be uncommented and used in your private `.env` file to keep track of the values you manually configure in `hotspot_config/hostapd.conf`:
+
+*   `# WIFI_SSID="YourHotspotSSID"`
+*   `# WIFI_PASSWORD="YourStrongPassword"`
+*   `# WIFI_COUNTRY_CODE="US"`
+
+**How It's Used:**
+
+*   **Docker Compose:** `docker-compose.yml` automatically loads variables from the `.env` file for use in service definitions.
+*   **Scripts:** Some scripts (like `scripts/cloudflare_ddns.py`) are designed to read these variables from the environment. Ensure the `.env` file is sourced or variables are otherwise exported when running such scripts (e.g., in a cron job).
+
+## III. Deployment and Execution Summary
 
 **Refer to the detailed README files within each component's directory for in-depth explanations and troubleshooting.**
 
@@ -67,11 +108,16 @@ surviving-chernarus/
 1.  **Static IP for `eth0` (Internet Interface):** Ensure your Raspberry Pi has a predictable static IP address on its main Ethernet interface (e.g., `eth0`) if it doesn't already. This is good practice for a server.
 2.  **Static IP for `wlan0` (Hotspot Interface):** Configure `wlan0` with the static IP `192.168.73.1` (netmask `255.255.255.0`). This can be done via `/etc/dhcpcd.conf` or network management tools. The `GUIDANCE_AND_EXPLANATIONS.md` provides an example.
 3.  **Install Required OS Packages:**
-    ```bash
-    sudo apt-get update
-    sudo apt-get install -y hostapd iptables-persistent docker.io docker-compose
-    ```
-    (Note: `docker.io` and `docker-compose` package names might vary. Use official Docker installation guides for Raspberry Pi OS if needed.)
+    *   **Pi-hole (Host):** Install Pi-hole on the host system using its official script. This provides the base DNS and DHCP capabilities.
+        ```bash
+        curl -sSL https://install.pi-hole.net | bash
+        ```
+    *   **Other Essential Packages:**
+        ```bash
+        sudo apt-get update
+        sudo apt-get install -y hostapd nftables curl jq python3 python3-pip docker.io docker-compose
+        ```
+        (Note: `jq` and `python3`/`python3-pip` are primarily for the Cloudflare DDNS script. `docker.io` and `docker-compose` package names might vary; use official Docker installation guides for Raspberry Pi OS if needed.)
 4.  **Enable Docker Service:**
     ```bash
     sudo systemctl enable docker
@@ -95,7 +141,7 @@ surviving-chernarus/
     # cd /opt/surviving-chernarus
     ```
 2.  **Review and Customize (CRITICAL):**
-    *   **`hotspot_config/hostapd.conf`:** Set a strong `wpa_passphrase`. Verify `country_code`.
+    *   **`hotspot_config/hostapd.conf`:** Set a strong `wpa_passphrase`. Verify `country_code`. Refer to the `.env.example` file for tracking your chosen `WIFI_SSID`, `WIFI_PASSWORD`, and `WIFI_COUNTRY_CODE`, which you will need to manually set in this file.
     *   **SSL CA Certificate:**
         1.  Generate your CA certificate (e.g., `myCA.pem` containing both key and cert). Refer to `squid_Berezino_Checkpoint/README_SQUID.md` for guidance.
         2.  Place this `myCA.pem` into `squid_Berezino_Checkpoint/certs/`.
@@ -120,11 +166,12 @@ surviving-chernarus/
     sudo pihole restartdns # or sudo systemctl restart pihole-FTL.service
     ```
     Verify in Pi-hole admin DHCP settings.
-3.  **NAT & Forwarding (Basic Internet):**
+    *   **Custom DNS for `.terrerov.com`:** This setup also includes a custom Pi-hole configuration to resolve `*.terrerov.com` (and its subdomains) to the Raspberry Pi's local IP (`192.168.73.1`). To enable this, copy `hotspot_config/dnsmasq_custom/03-terrerov-domain.conf` to `/etc/dnsmasq.d/` on your Pi-hole host and restart Pi-hole DNS (`sudo pihole restartdns`).
+3.  **NAT & Forwarding (Basic Internet with nftables):**
     ```bash
-    chmod +x scripts/setup_hotspot_nat.sh
-    sudo ./scripts/setup_hotspot_nat.sh
-    sudo netfilter-persistent save # Persist iptables rules
+    chmod +x scripts/setup_hotspot_nat_nft.sh
+    sudo ./scripts/setup_hotspot_nat_nft.sh
+    # Rules are applied by the script. See "nftables Rule Order and Persistence" below.
     ```
 
 **Phase 4: Setup Captive Portal (`Chernarus_Entrypoint`)**
@@ -134,12 +181,11 @@ surviving-chernarus/
     sudo docker-compose up -d
     ```
     Check logs: `sudo docker-compose logs -f chernarus_entrypoint`
-2.  **`iptables` Redirection to Portal:**
+2.  **`nftables` Redirection to Portal:**
     ```bash
-    chmod +x scripts/setup_captive_portal_redirect.sh
-    sudo ./scripts/setup_captive_portal_redirect.sh
-    # This script attempts to insert rules at the top. Review rule order if issues.
-    sudo netfilter-persistent save
+    chmod +x scripts/setup_captive_portal_redirect_nft.sh
+    sudo ./scripts/setup_captive_portal_redirect_nft.sh
+    # This script adds rules. See "nftables Rule Order and Persistence" below.
     ```
 
 **Phase 5: Setup Squid Proxy (`Berezino_Checkpoint`)**
@@ -149,20 +195,35 @@ surviving-chernarus/
     sudo docker-compose up -d
     ```
     Check logs: `sudo docker-compose logs -f berezino_checkpoint`
-2.  **`iptables` Redirection to Squid:**
+2.  **`nftables` Redirection to Squid:**
     ```bash
-    chmod +x scripts/redirect_to_squid.sh
-    sudo ./scripts/redirect_to_squid.sh
-    # This script adds rules after the portal's expected rules.
-    sudo netfilter-persistent save
+    chmod +x scripts/redirect_to_squid_nft.sh
+    sudo ./scripts/redirect_to_squid_nft.sh
+    # This script adds rules. See "nftables Rule Order and Persistence" below.
     ```
 
-**Order of `iptables` Script Execution for NAT Table (`PREROUTING` chain for `wlan0`):**
-The system relies on `iptables` rules being applied in a specific sequence. If you need to reset or reapply:
-1.  `scripts/setup_hotspot_nat.sh` (Basic NAT/Forwarding - less specific, broader rules)
-2.  `scripts/setup_captive_portal_redirect.sh` (Redirects HTTP to portal - more specific, should be early)
-3.  `scripts/redirect_to_squid.sh` (Redirects HTTP/HTTPS to Squid - processes what's left or bypasses portal for HTTPS)
-Always save rules with `sudo netfilter-persistent save` after changes.
+**nftables Rule Order and Persistence:**
+
+The `nftables` firewall rules are critical and must be applied in a specific order. The provided scripts are designed to manage this:
+
+1.  **`scripts/setup_hotspot_nat_nft.sh`**: This script should be run **first**. It flushes all existing rules and establishes the base NAT and firewall rules for hotspot internet access.
+2.  **`scripts/setup_captive_portal_redirect_nft.sh`**: This script should be run **second**. It adds rules to redirect unauthenticated clients to the captive portal. It assumes the base rules from the NAT script are in place.
+3.  **`scripts/redirect_to_squid_nft.sh`**: This script should be run **third (typically after client authentication or if portal is bypassed)**. It adds rules to transparently redirect HTTP/HTTPS traffic to the Squid proxy, including bypasses for local RPi services.
+
+**Persistence:**
+The `nftables` rules applied by these scripts are temporary and will be lost on reboot unless saved. To make them permanent:
+*   **After running all three scripts in the correct order and verifying functionality:**
+    1.  Save the current (working) ruleset to the default `nftables` configuration file:
+        ```bash
+        sudo nft list ruleset > /etc/nftables.conf
+        ```
+        *(This command overwrites `/etc/nftables.conf`. Review existing content if any, or merge rules carefully if you have pre-existing `nftables` configurations.)*
+    2.  Enable the `nftables` service to automatically load these rules at boot:
+        ```bash
+        sudo systemctl enable nftables.service
+        sudo systemctl start nftables.service
+        ```
+*   You can check the status of the service with `sudo systemctl status nftables.service` and view loaded rules with `sudo nft list ruleset`.
 
 **Phase 6: Client Device Configuration**
 1.  Connect a client device to the `rpi` Wi-Fi SSID.
@@ -176,9 +237,18 @@ Always save rules with `sudo netfilter-persistent save` after changes.
 *   **`project_rules.md` and `user_rules.md`:** These files were not accessible. Configurations are based on standard practices.
 *   **Pi-hole (`StarySobor_RadioPost`) Setup:** Assumes Pi-hole is already installed, functional, and accessible at `192.168.73.1` for DNS by hotspot clients.
 *   **Internet Connectivity:** Assumes `eth0` (or your primary internet interface) is configured for internet access.
-*   **Firewall Base State:** Assumes a relatively permissive default `iptables` policy. The provided scripts add necessary rules for the project's functionality.
+*   **Firewall Base State:** Assumes a relatively permissive default `nftables` policy (or that the scripts will correctly flush and apply rules). The provided scripts are designed to set up the necessary rules.
 *   **Security of CA Key:** The CA private key is highly sensitive. Protect it. The `.pem` file in `squid_Berezino_Checkpoint/certs/` should have restricted permissions on the host.
-*   **Thematic Hostnames in DNS:** For hostnames like `berezino-checkpoint` to be resolvable by clients, add them to Pi-hole's "Local DNS Records" pointing to `192.168.73.1`.
-*   **`iptables` vs. `nftables`:** This solution uses `iptables`. If your system uses `nftables` as the default backend, script adjustments will be needed.
+*   **Thematic Hostnames in DNS:** For hostnames like `berezino-checkpoint` to be resolvable by clients, add them to Pi-hole's "Local DNS Records" pointing to `192.168.73.1`, or use the `*.terrerov.com` feature.
+*   **Firewall Backend:** This solution now uses `nftables`. The scripts are written for `nftables`.
+
+## IV. Advanced Configuration & Automation
+
+### Cloudflare Dynamic DNS (DDNS)
+
+For automatically updating a Cloudflare DNS record with your Raspberry Pi's dynamic public IP, this project includes the `scripts/cloudflare_ddns.py` script. This is useful if your ISP assigns you a dynamic public IP address.
+
+Detailed setup instructions, including API token generation and cron job setup, are available in the wiki:
+*   [Configurar DDNS con Cloudflare](wiki/es/15-Configurar-DDNS-Cloudflare.md)
 
 This concludes the setup for "Operación: The Perimeter". Review all component READMEs and configurations carefully before and during deployment. Remember to test each phase incrementally. Good luck, survivor!

--- a/captive_portal_Chernarus_Entrypoint/README_PORTAL.md
+++ b/captive_portal_Chernarus_Entrypoint/README_PORTAL.md
@@ -7,7 +7,7 @@ This guide provides instructions for setting up the `Chernarus_Entrypoint` capti
 1.  **`captive_portal_Chernarus_Entrypoint/docker-compose.yml`**: Docker Compose configuration to run Nginx for serving the portal page.
 2.  **`captive_portal_Chernarus_Entrypoint/html/index.html`**: The static HTML page for the portal.
 3.  **`captive_portal_Chernarus_Entrypoint/html/.gitkeep`**: Ensures the `html` directory is tracked.
-4.  **`scripts/setup_captive_portal_redirect.sh`**: Script to set up `iptables` rules for redirecting new hotspot clients to the portal.
+4.  **`scripts/setup_captive_portal_redirect_nft.sh`**: Script to set up `nftables` rules for redirecting new hotspot clients to the portal.
 
 ## I. Prerequisites
 
@@ -56,54 +56,57 @@ The `captive_portal_Chernarus_Entrypoint/docker-compose.yml` file defines the Ng
     ```
     Ensure Nginx is running without errors. You should be able to access `http://<RPi_IP>:8080` (e.g., `http://192.168.73.1:8080`) from a device on the RPi's network (or from the RPi itself).
 
-## IV. `iptables` Traffic Redirection
+## IV. `nftables` Traffic Redirection
 
-The `scripts/setup_captive_portal_redirect.sh` script configures `iptables` to redirect new users on the hotspot to the captive portal page.
+The `scripts/setup_captive_portal_redirect_nft.sh` script configures `nftables` to redirect new users on the hotspot to the captive portal page.
 
 1.  **Review the Script:**
-    Familiarize yourself with `scripts/setup_captive_portal_redirect.sh`. It's designed to redirect HTTP (port 80) traffic from `wlan0` clients to the portal at `192.168.73.1:8080`.
+    Familiarize yourself with `scripts/setup_captive_portal_redirect_nft.sh`. It's designed to redirect HTTP (port 80) traffic from `wlan0` clients to the portal at `192.168.73.1:8080`. It does this by adding a DNAT rule to the `prerouting` chain in the `nat` table (or a similarly named table if you've customized `setup_hotspot_nat_nft.sh`).
 
 2.  **Make it Executable:**
     ```bash
-    chmod +x path/to/your/cloned/repository/scripts/setup_captive_portal_redirect.sh
+    chmod +x path/to/your/cloned/repository/scripts/setup_captive_portal_redirect_nft.sh
     ```
 
 3.  **Run the Script:**
     Execute it with `sudo` privileges:
     ```bash
-    sudo path/to/your/cloned/repository/scripts/setup_captive_portal_redirect.sh
+    sudo path/to/your/cloned/repository/scripts/setup_captive_portal_redirect_nft.sh
     ```
 
-**Redirection Strategy and `iptables` Rule Order:**
+**Redirection Strategy and `nftables` Rule Order:**
 
-*   **Simplified Approach:** The script inserts an `iptables` rule at the *top* of the `PREROUTING` chain in the `nat` table. This rule redirects all HTTP (port 80) requests from hotspot clients (`wlan0`) to the portal at `http://192.168.73.1:8080`.
+*   **Approach:** The script adds a DNAT rule for HTTP (port 80) requests from hotspot clients (`wlan0`) to the portal at `http://192.168.73.1:8080`. This rule is typically inserted with high precedence to catch traffic before other general NAT rules.
 *   **How it Works:**
     1.  A new user connects to the `rpi` Wi-Fi.
     2.  Their first HTTP request (e.g., to `http://example.com`) is caught by this rule and redirected.
     3.  They see the `index.html` page, download, and install the CA certificate.
     4.  After CA installation, HTTPS sites should work via the Squid proxy.
 *   **Limitation:** HTTP sites will *continue* to be redirected to the portal. This might be acceptable if most critical browsing is HTTPS.
-*   **Order of Execution for `iptables` Scripts:** For the whole system to work as intended, scripts affecting `iptables` should be run in a specific order:
-    1.  `scripts/setup_hotspot_nat.sh` (Basic NAT and forwarding for internet access)
-    2.  `scripts/setup_captive_portal_redirect.sh` (This portal redirection script - for HTTP)
-    3.  `scripts/redirect_to_squid.sh` (Redirects HTTP and HTTPS to Squid)
-    The portal script attempts to insert its rule first, ensuring it's processed before Squid's HTTP redirection.
+*   **Order of Execution for `nftables` Scripts:** For the whole system to work as intended, scripts affecting `nftables` should be run in a specific order, as detailed in the main project `README.md` and `GUIDANCE_AND_EXPLANATIONS.md`:
+    1.  `scripts/setup_hotspot_nat_nft.sh` (Basic NAT and firewall setup)
+    2.  `scripts/setup_captive_portal_redirect_nft.sh` (This portal redirection script - for HTTP)
+    3.  `scripts/redirect_to_squid_nft.sh` (Redirects HTTP and HTTPS to Squid)
+    The `setup_hotspot_nat_nft.sh` script typically flushes rules, so it must be run first. The portal script then adds its specific rules.
 
 *   **Alternative (No Automatic Redirection):** If you prefer not to redirect all HTTP traffic:
-    *   Do not run `scripts/setup_captive_portal_redirect.sh`.
+    *   Do not run `scripts/setup_captive_portal_redirect_nft.sh`.
     *   Modify Nginx in `captive_portal_Chernarus_Entrypoint/docker-compose.yml` to listen directly on port 80 (e.g., `ports: - "80:80"`), assuming no other service on the Pi uses port 80.
-    *   Instruct users to manually visit a specific address like `http://192.168.73.1` or a friendly DNS name (e.g., `http://welcome.chernarus.local`) that you configure in Pi-hole to point to `192.168.73.1`.
+    *   Instruct users to manually visit a specific address like `http://192.168.73.1` or a friendly DNS name (e.g., `http://welcome.chernarus.local` or `http://welcome.terrerov.com`) that you configure in Pi-hole to point to `192.168.73.1`.
 
 4.  **Persistence:**
-    The `iptables` rules are volatile. After confirming functionality:
-    *   Install `iptables-persistent` if not already done: `sudo apt-get update && sudo apt-get install -y iptables-persistent`
-    *   Save the rules: `sudo netfilter-persistent save`
-    *   If you re-run any of the `iptables` setup scripts or manually change rules, remember to save them again.
+    The `nftables` rules are volatile. After confirming functionality by running all necessary `nftables` scripts in the correct order:
+    *   Ensure `nftables` service is enabled: `sudo systemctl enable nftables.service`
+    *   Save the current complete ruleset:
+        ```bash
+        sudo nft list ruleset > /etc/nftables.conf
+        ```
+    *   If you re-run any of the `nftables` setup scripts or manually change rules, remember to save the complete, working ruleset again to `/etc/nftables.conf`.
 
 ## V. Testing
 
 1.  Ensure `Chernarus_Entrypoint` (Nginx) and `Berezino_Checkpoint` (Squid) Docker containers are running.
-2.  Ensure `iptables` rules from all relevant scripts (`setup_hotspot_nat.sh`, `setup_captive_portal_redirect.sh`, `redirect_to_squid.sh`) have been applied in the correct order.
+2.  Ensure `nftables` rules from all relevant scripts (`setup_hotspot_nat_nft.sh`, `setup_captive_portal_redirect_nft.sh`, `redirect_to_squid_nft.sh`) have been applied in the correct order and saved persistently (e.g., `sudo nft list ruleset > /etc/nftables.conf` followed by enabling `nftables.service`).
 3.  Connect a **new client device** to the `rpi` Wi-Fi hotspot.
 4.  Open a web browser on the client and attempt to visit an **HTTP** website (e.g., `http://neverssl.com` or `http://example.com`). You should be redirected to the `Chernarus_Entrypoint` portal page (`http://192.168.73.1:8080`).
 5.  From the portal page, download the `Chernarus_Root_CA.pem` (or `.crt`) file.
@@ -118,9 +121,20 @@ To stop the Nginx portal service:
 cd path/to/your/cloned/repository/captive_portal_Chernarus_Entrypoint/
 docker-compose down
 ```
-This does not remove the `iptables` redirection rules. If you want to disable portal redirection, you'll need to manually remove the specific `iptables` rule or flush the `PREROUTING` chain (carefully, if other rules exist) and re-apply only the Squid redirection.
-Example to delete the portal rule (if it's the first one in PREROUTING nat):
-`sudo iptables -t nat -D PREROUTING 1`
-Then re-save with `sudo netfilter-persistent save`.
+This does not remove the `nftables` redirection rules. If you want to disable portal redirection:
+1.  **Identify the rule:** List your ruleset with handles:
+    ```bash
+    sudo nft list ruleset -a
+    ```
+    Locate the rule responsible for portal redirection (e.g., in `ip nat_table prerouting`, it might have a comment like "DNAT HTTP from wlan0 to Captive Portal..."). Note its handle.
+2.  **Delete the rule:**
+    ```bash
+    sudo nft delete rule ip nat_table prerouting handle <handle_number>
+    ```
+    Replace `<handle_number>` with the actual handle. (Table and chain names might vary if you customized them).
+3.  **Alternatively, edit `/etc/nftables.conf`:** Manually remove or comment out the specific rule definition from `/etc/nftables.conf`.
+4.  **Reload `nftables` or save the ruleset:**
+    *   If you edited `/etc/nftables.conf`: `sudo systemctl reload nftables.service`
+    *   If you used `nft delete rule`: `sudo nft list ruleset > /etc/nftables.conf` to save the new state.
 
 This completes the setup for the `Chernarus_Entrypoint` captive portal.

--- a/captive_portal_Chernarus_Entrypoint/html/index.html
+++ b/captive_portal_Chernarus_Entrypoint/html/index.html
@@ -42,7 +42,7 @@
             <li>
                 <strong>Download the CA Certificate:</strong>
                 <!-- User must place their myCA.pem (or .crt) file in the html directory and update this link -->
-                <p><a href="/myCA.pem" download="Chernarus_Root_CA.pem" class="button">Download Chernarus_Root_CA.pem</a></p>
+                <p><a href="/myCA.crt" download="Chernarus_Root_CA.crt" class="button">Download Chernarus_Root_CA.crt</a></p>
                 <p>(If the download doesn't start, ensure `myCA.pem` is present in the `captive_portal_Chernarus_Entrypoint/html/` directory on the server and this link points to the correct filename.)</p>
             </li>
             <li>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,12 +37,10 @@ services:
     container_name: Pihole_DNS_Filter
     hostname: pihole-dns-filter
     ports:
-      - "53:53/tcp"
-      - "53:53/udp"
       - "8081:80/tcp"
     environment:
-      TZ: 'America/Chicago'
-      WEBPASSWORD: 'ChangeThisPasswordPlease' # IMPORTANT: Change this password!
+      TZ: '${TZ}'
+      WEBPASSWORD: '${PIHOLE_WEBPASSWORD}' # IMPORTANT: Change this password!
       DNSMASQ_LISTENING: 'all'
     volumes:
       - pihole_etc_pihole:/etc/pihole
@@ -52,20 +50,6 @@ services:
     networks:
       - frontend_network
     restart: unless-stopped
-
-  dhcp_server:
-    image: networkboot/dhcpd
-    container_name: Hotspot_DHCP_Server
-    hostname: hotspot-dhcp-server
-    network_mode: "host" # Critical for DHCP
-    volumes:
-      - ./hotspot_config/dhcp/dhcpd.conf:/data/dhcpd.conf # Path inside container might vary based on image
-    cap_add:
-      - NET_ADMIN
-      - NET_RAW
-    restart: unless-stopped
-    # User MUST verify and change "wlan0" to their actual WiFi interface
-    command: ["-cf", "/data/dhcpd.conf", "-f", "wlan0"]
 
   dashboard_placeholder:
     image: nginx:alpine

--- a/hotspot_config/dnsmasq_custom/03-terrerov-domain.conf
+++ b/hotspot_config/dnsmasq_custom/03-terrerov-domain.conf
@@ -1,0 +1,4 @@
+# Custom DNS configuration for resolving .terrerov.com domain
+# This file should be placed in /etc/dnsmasq.d/ on the Pi-hole host
+# (e.g., as 03-terrerov-domain.conf or similar) and FTL restarted.
+address=/.terrerov.com/192.168.73.1

--- a/readme_env_section.md
+++ b/readme_env_section.md
@@ -1,0 +1,69 @@
+## Centralized Configuration (.env file)
+
+To manage sensitive information (like API keys and passwords) and environment-specific settings, this project utilizes a `.env` file located in the project root (`/opt/surviving-chernarus/.env`). This approach keeps your secrets out of version control and makes configuration more straightforward.
+
+### Purpose
+
+The primary purpose of using a `.env` file is to:
+*   **Secure Sensitive Data:** Keep API tokens, passwords, and other private details separate from the main codebase.
+*   **Simplify Configuration:** Provide a single place to define settings that might change between different deployment environments or user preferences.
+*   **Avoid Hardcoding:** Prevent embedding secrets directly into scripts or configuration files.
+
+### `.env.example` Template
+
+A template file named `.env.example` is provided in the project root. You should copy this template to create your own `.env` file:
+
+```bash
+cp .env.example .env
+```
+
+After copying, edit the `.env` file with your specific values.
+
+### `.gitignore` - Crucial Security Step
+
+**It is absolutely crucial to prevent your actual `.env` file (which contains your secrets) from being committed to version control (Git).**
+
+If you are using Git for this project, add `.env` to your `.gitignore` file immediately:
+
+```bash
+echo '.env' >> .gitignore
+```
+
+This ensures that your sensitive information remains local to your deployment.
+
+### Variables to Configure
+
+The following variables are present in `.env.example` and should be configured in your `.env` file:
+
+*   **`PIHOLE_WEBPASSWORD`**:
+    *   **Purpose:** Sets the administrator password for the Pi-hole Docker container's web interface.
+    *   **Example:** `YourPiholeAdminPassword`
+
+*   **`TZ`**:
+    *   **Purpose:** Defines the timezone for the Pi-hole Docker container (e.g., logs, scheduled tasks).
+    *   **Example:** `America/Chicago` (Find your timezone from standard lists, e.g., [Wikipedia TZ Database Time Zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))
+
+*   **`CLOUDFLARE_API_TOKEN`**:
+    *   **Purpose:** Your Cloudflare API token with permissions to edit DNS records for your zone. This is used by the DDNS script (`scripts/cloudflare_ddns.py`).
+    *   **Example:** `YourCloudflareAPIToken` (See `wiki/es/15-Configurar-DDNS-Cloudflare.md` for instructions on obtaining this token)
+
+*   **`CLOUDFLARE_ZONE_NAME`**:
+    *   **Purpose:** The root domain name you manage in Cloudflare (e.g., `terrerov.com`). Used by the DDNS script.
+    *   **Example:** `terrerov.com`
+
+*   **`CLOUDFLARE_RECORD_NAME`**:
+    *   **Purpose:** The specific DNS 'A' record you want the DDNS script to update (e.g., `rpi.terrerov.com`).
+    *   **Example:** `rpi.terrerov.com`
+
+*   **Reference Wi-Fi Variables (Commented Out):**
+    *   `# WIFI_SSID="YourHotspotSSID"`
+    *   `# WIFI_PASSWORD="YourStrongPassword"`
+    *   `# WIFI_COUNTRY_CODE="US"`
+    *   **Purpose:** These are provided as a **reference only**. The hotspot configuration in `hostapd.conf` requires direct editing by the user. However, you can uncomment and use these variables in your `.env` file to keep a personal record of the SSID, password, and country code you have configured in `hostapd.conf`. This project **does not** automatically use these specific `.env` variables to configure `hostapd`.
+
+### How It's Used
+
+*   **Docker Compose:** `docker-compose.yml` is configured to automatically read and load variables from the `.env` file in the project root when starting services (like Pi-hole).
+*   **Shell Scripts:** Some scripts, particularly those run by cron jobs (like `scripts/cloudflare_ddns.py`), are designed to have the `.env` file sourced before execution. This loads the variables into the script's environment. Detailed instructions are provided in the documentation for each relevant script (e.g., the cron setup for `cloudflare_ddns.py`).
+
+By centralizing these configurations, you create a more secure and manageable setup for your Surviving Chernarus hotspot project. Remember to always keep your `.env` file private.

--- a/scripts/cloudflare_ddns.py
+++ b/scripts/cloudflare_ddns.py
@@ -1,0 +1,151 @@
+import requests
+import os
+# import logging # Actual logging can be added later if needed
+
+# Configuration will be via environment variables
+# CLOUDFLARE_API_TOKEN = os.getenv("CLOUDFLARE_API_TOKEN")
+# ZONE_NAME = os.getenv("CLOUDFLARE_ZONE_NAME")
+# RECORD_NAME = os.getenv("CLOUDFLARE_RECORD_NAME")
+
+def get_public_ip():
+    """
+    Fetches the public IP address from a list of online services.
+    Returns:
+        str: The public IP address as a string, or None if fetching failed.
+    """
+    ip_services = ["https://api.ipify.org", "https://icanhazip.com", "https://ifconfig.me/ip"]
+    for service_url in ip_services:
+        try:
+            response = requests.get(service_url, timeout=10) # Increased timeout slightly
+            response.raise_for_status() # Raises HTTPError for bad responses (4XX or 5XX)
+            return response.text.strip()
+        except requests.RequestException as e:
+            print(f"Warning: Failed to get IP from {service_url}: {e}")
+    print("Error: Failed to obtain public IP from all services.")
+    return None
+
+def get_zone_id(zone_name, api_token):
+    """
+    Retrieves the Zone ID for a given zone name from Cloudflare.
+    Args:
+        zone_name (str): The name of the Cloudflare zone (e.g., "example.com").
+        api_token (str): The Cloudflare API token.
+    Returns:
+        str: The Zone ID, or None if not found or an error occurred.
+    """
+    headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+    url = f"https://api.cloudflare.com/client/v4/zones?name={zone_name}"
+    try:
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        if data.get("result") and len(data["result"]) > 0:
+            return data["result"][0]["id"]
+        else:
+            print(f"Error: Zone '{zone_name}' not found or API token lacks permissions.")
+            return None
+    except requests.RequestException as e:
+        print(f"Error: Cloudflare API error (get_zone_id): {e} - {e.response.text if e.response is not None and hasattr(e.response, 'text') else 'No response text'}")
+        return None
+
+def get_dns_record(zone_id, record_name, api_token):
+    """
+    Retrieves a specific DNS 'A' record from Cloudflare.
+    Args:
+        zone_id (str): The Cloudflare Zone ID.
+        record_name (str): The full DNS record name (e.g., "ddns.example.com").
+        api_token (str): The Cloudflare API token.
+    Returns:
+        dict: The DNS record details as a dictionary, or None if not found or an error occurred.
+    """
+    headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+    url = f"https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records?type=A&name={record_name}"
+    try:
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        if data.get("result") and len(data["result"]) > 0:
+            return data["result"][0] # Returns the first 'A' record found with that name
+        else:
+            # This is not necessarily an error, the record might not exist yet.
+            print(f"Info: DNS record '{record_name}' not found in zone ID '{zone_id}'.")
+            return None
+    except requests.RequestException as e:
+        print(f"Error: Cloudflare API error (get_dns_record): {e} - {e.response.text if e.response is not None and hasattr(e.response, 'text') else 'No response text'}")
+        return None
+
+def update_dns_record(zone_id, record_id, record_name, new_ip, api_token):
+    """
+    Updates an existing DNS 'A' record in Cloudflare.
+    Args:
+        zone_id (str): The Cloudflare Zone ID.
+        record_id (str): The ID of the DNS record to update.
+        record_name (str): The full DNS record name.
+        new_ip (str): The new IP address to set for the record.
+        api_token (str): The Cloudflare API token.
+    Returns:
+        bool: True if the update was successful, False otherwise.
+    """
+    headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+    url = f"https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records/{record_id}"
+    payload = {
+        "type": "A",
+        "name": record_name,
+        "content": new_ip,
+        "ttl": 120,      # Time to Live in seconds. 120 is 2 minutes. 1 means 'automatic'.
+        "proxied": False # False for DNS-only. True to enable Cloudflare proxy/CDN.
+    }
+    try:
+        response = requests.put(url, headers=headers, json=payload, timeout=10)
+        response.raise_for_status()
+        print(f"Successfully updated DNS record '{record_name}' to '{new_ip}'.")
+        return True
+    except requests.RequestException as e:
+        print(f"Error: Cloudflare API error (update_dns_record): {e} - {e.response.text if e.response is not None and hasattr(e.response, 'text') else 'No response text'}")
+        return False
+
+# Note: A create_dns_record function would be similar to update_dns_record,
+# but using POST to /zones/{zone_id}/dns_records and not needing a record_id.
+# This script assumes the A record is pre-created in Cloudflare.
+
+if __name__ == "__main__":
+    print("Cloudflare DDNS Script starting...")
+
+    # Retrieve configuration from environment variables
+    CLOUDFLARE_API_TOKEN = os.getenv("CLOUDFLARE_API_TOKEN")
+    ZONE_NAME = os.getenv("CLOUDFLARE_ZONE_NAME")           # e.g., "example.com"
+    RECORD_NAME = os.getenv("CLOUDFLARE_RECORD_NAME")       # e.g., "ddns.example.com" or "example.com" for root
+
+    if not all([CLOUDFLARE_API_TOKEN, ZONE_NAME, RECORD_NAME]):
+        print("Error: Missing one or more required environment variables: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ZONE_NAME, CLOUDFLARE_RECORD_NAME")
+        exit(1)
+
+    # 1. Get current public IP
+    public_ip = get_public_ip()
+    if not public_ip:
+        print("Exiting: Could not determine public IP.")
+        exit(1)
+    print(f"Current public IP: {public_ip}")
+
+    # 2. Get Cloudflare Zone ID
+    zone_id = get_zone_id(ZONE_NAME, CLOUDFLARE_API_TOKEN)
+    if not zone_id:
+        print(f"Exiting: Could not determine Zone ID for {ZONE_NAME}.")
+        exit(1)
+    print(f"Zone ID for '{ZONE_NAME}': {zone_id}")
+
+    # 3. Get current DNS record from Cloudflare
+    dns_record = get_dns_record(zone_id, RECORD_NAME, CLOUDFLARE_API_TOKEN)
+
+    if dns_record:
+        current_cf_ip = dns_record["content"]
+        print(f"Current Cloudflare IP for '{RECORD_NAME}': {current_cf_ip}")
+        if public_ip == current_cf_ip:
+            print("IP addresses match. No update needed.")
+        else:
+            print(f"IP addresses differ ({public_ip} vs {current_cf_ip}). Updating Cloudflare DNS record...")
+            update_dns_record(zone_id, dns_record["id"], RECORD_NAME, public_ip, CLOUDFLARE_API_TOKEN)
+    else:
+        print(f"Warning: DNS A record '{RECORD_NAME}' not found. Please create it manually in Cloudflare for initial setup.")
+        # Optionally, could call a create_dns_record function here if implemented.
+    print("Cloudflare DDNS Script finished.")

--- a/scripts/redirect_to_squid_nft.sh
+++ b/scripts/redirect_to_squid_nft.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# === Configuration ===
+# Network interface for the Wi-Fi Hotspot (LAN)
+WLAN_IF="wlan0" # IMPORTANT: User MUST verify and change
+
+# Subnet for the Wi-Fi Hotspot
+HOTSPOT_NET="192.168.73.0/24" # IMPORTANT: User MUST verify and change
+
+# IP Address of the Raspberry Pi on the WLAN interface
+RPI_WLAN_IP="192.168.73.1" # IMPORTANT: User MUST verify and change
+
+# Port where the Captive Portal Nginx is listening (from docker-compose)
+PORTAL_HOST_PORT="8080" # IMPORTANT: User MUST verify and change
+
+# Squid Proxy Ports (ensure these match squid.conf and docker-compose)
+SQUID_HTTP_PORT="3128"  # Squid's HTTP listening port
+SQUID_HTTPS_PORT="3129" # Squid's HTTPS (ssl-bump) listening port
+
+# === Script Start ===
+echo "Starting Squid Proxy Redirect Setup using nftables..."
+
+# Check if nftables is installed
+if ! command -v nft &> /dev/null; then
+    echo "[ERROR] nftables command could not be found. Please install nftables first."
+    echo "You can usually install it with: sudo apt update && sudo apt install nftables -y"
+    exit 1
+fi
+
+# Ensure base tables and chains are likely present (informational)
+echo "[INFO] This script assumes base tables 'inet firewall_table' and 'ip nat_table' exist,"
+echo "       and chains 'inet firewall_table input' and 'ip nat_table prerouting' exist."
+echo "       These are typically created by 'setup_hotspot_nat_nft.sh' and potentially"
+echo "       modified by 'setup_captive_portal_redirect_nft.sh'."
+
+# === 1. PREROUTING Bypass Rules for RPi Local Services ===
+# These rules ensure traffic to essential RPi services (DNS, DHCP, local web/portal)
+# is NOT redirected to Squid. They are inserted after the captive portal's main redirect rule (pos 0).
+
+# --- Bypass rule for local Web/Portal services (HTTP, HTTPS, Portal Port) ---
+BYPASS_WEB_COMMENT="Bypass Squid for RPi Web/Portal (80,443,$PORTAL_HOST_PORT) on $RPI_WLAN_IP"
+BYPASS_WEB_CMD="sudo nft insert rule ip nat_table prerouting position 1 iifname \"$WLAN_IF\" ip daddr \"$RPI_WLAN_IP\" tcp dport {80, 443, $PORTAL_HOST_PORT} return comment \"$BYPASS_WEB_COMMENT\""
+
+if sudo nft list ruleset | grep -qF -- "$BYPASS_WEB_COMMENT"; then
+    echo "[INFO] Prerouting bypass rule for RPi Web/Portal services already seems to exist. Skipping."
+else
+    echo "[INFO] Adding PREROUTING bypass rule for RPi Web/Portal services..."
+    eval "$BYPASS_WEB_CMD"
+    if [ $? -ne 0 ]; then echo "[ERROR] Failed to add PREROUTING bypass for RPi Web/Portal. Exiting."; exit 1; fi
+    echo "[SUCCESS] PREROUTING bypass for RPi Web/Portal added."
+fi
+
+# --- Bypass rule for local DNS/DHCP services (UDP) ---
+BYPASS_DNS_DHCP_COMMENT="Bypass Squid for RPi DNS/DHCP (53,67,68) on $RPI_WLAN_IP"
+# Insert after the web bypass rule, so position 2 if web bypass was added, or 1 if not.
+# For simplicity, we'll always try to insert at a fixed position relative to the start.
+# Assuming captive portal redirect is at 0, web bypass at 1.
+BYPASS_DNS_DHCP_CMD="sudo nft insert rule ip nat_table prerouting position 2 iifname \"$WLAN_IF\" ip daddr \"$RPI_WLAN_IP\" udp dport {53, 67, 68} return comment \"$BYPASS_DNS_DHCP_COMMENT\""
+
+if sudo nft list ruleset | grep -qF -- "$BYPASS_DNS_DHCP_COMMENT"; then
+    echo "[INFO] Prerouting bypass rule for RPi DNS/DHCP services already seems to exist. Skipping."
+else
+    echo "[INFO] Adding PREROUTING bypass rule for RPi DNS/DHCP services..."
+    eval "$BYPASS_DNS_DHCP_CMD"
+    if [ $? -ne 0 ]; then echo "[ERROR] Failed to add PREROUTING bypass for RPi DNS/DHCP. Exiting."; exit 1; fi
+    echo "[SUCCESS] PREROUTING bypass for RPi DNS/DHCP added."
+fi
+
+# === 2. PREROUTING DNAT Rules for Squid Proxy ===
+# These rules redirect HTTP and HTTPS traffic from the hotspot network to Squid.
+# They are added after the bypass rules.
+
+# --- DNAT HTTP to Squid ---
+SQUID_HTTP_DNAT_COMMENT="DNAT HTTP from $HOTSPOT_NET on $WLAN_IF to Squid 127.0.0.1:$SQUID_HTTP_PORT"
+# This rule is added to the end of the chain (append) to ensure it's processed after specific bypasses and portal redirects.
+SQUID_HTTP_DNAT_CMD="sudo nft add rule ip nat_table prerouting iifname \"$WLAN_IF\" ip saddr \"$HOTSPOT_NET\" ip daddr != \"$RPI_WLAN_IP\" tcp dport 80 dnat to \"127.0.0.1:$SQUID_HTTP_PORT\" comment \"$SQUID_HTTP_DNAT_COMMENT\""
+
+if sudo nft list ruleset | grep -qF -- "$SQUID_HTTP_DNAT_COMMENT"; then
+    echo "[INFO] Prerouting DNAT rule for HTTP to Squid already seems to exist. Skipping."
+else
+    echo "[INFO] Adding PREROUTING DNAT rule for HTTP to Squid..."
+    eval "$SQUID_HTTP_DNAT_CMD"
+    if [ $? -ne 0 ]; then echo "[ERROR] Failed to add PREROUTING DNAT for HTTP to Squid. Exiting."; exit 1; fi
+    echo "[SUCCESS] PREROUTING DNAT for HTTP to Squid added."
+fi
+
+# --- DNAT HTTPS to Squid ---
+SQUID_HTTPS_DNAT_COMMENT="DNAT HTTPS from $HOTSPOT_NET on $WLAN_IF to Squid 127.0.0.1:$SQUID_HTTPS_PORT"
+SQUID_HTTPS_DNAT_CMD="sudo nft add rule ip nat_table prerouting iifname \"$WLAN_IF\" ip saddr \"$HOTSPOT_NET\" ip daddr != \"$RPI_WLAN_IP\" tcp dport 443 dnat to \"127.0.0.1:$SQUID_HTTPS_PORT\" comment \"$SQUID_HTTPS_DNAT_COMMENT\""
+
+if sudo nft list ruleset | grep -qF -- "$SQUID_HTTPS_DNAT_COMMENT"; then
+    echo "[INFO] Prerouting DNAT rule for HTTPS to Squid already seems to exist. Skipping."
+else
+    echo "[INFO] Adding PREROUTING DNAT rule for HTTPS to Squid..."
+    eval "$SQUID_HTTPS_DNAT_CMD"
+    if [ $? -ne 0 ]; then echo "[ERROR] Failed to add PREROUTING DNAT for HTTPS to Squid. Exiting."; exit 1; fi
+    echo "[SUCCESS] PREROUTING DNAT for HTTPS to Squid added."
+fi
+
+# === 3. INPUT Rules for Squid Traffic on Host ===
+# These rules allow the RPi itself to accept the traffic redirected to Squid's local ports.
+
+# --- Allow HTTP traffic to local Squid port ---
+SQUID_HTTP_INPUT_COMMENT="Allow HTTP from $HOTSPOT_NET on $WLAN_IF to local Squid 127.0.0.1:$SQUID_HTTP_PORT"
+SQUID_HTTP_INPUT_CMD="sudo nft add rule inet firewall_table input iifname \"$WLAN_IF\" ip saddr \"$HOTSPOT_NET\" ip daddr \"127.0.0.1\" tcp dport \"$SQUID_HTTP_PORT\" accept comment \"$SQUID_HTTP_INPUT_COMMENT\""
+
+if sudo nft list ruleset | grep -qF -- "$SQUID_HTTP_INPUT_COMMENT"; then
+    echo "[INFO] Input rule for local Squid HTTP traffic already seems to exist. Skipping."
+else
+    echo "[INFO] Adding INPUT rule for local Squid HTTP traffic..."
+    eval "$SQUID_HTTP_INPUT_CMD"
+    if [ $? -ne 0 ]; then echo "[ERROR] Failed to add INPUT rule for local Squid HTTP. Exiting."; exit 1; fi
+    echo "[SUCCESS] INPUT rule for local Squid HTTP added."
+fi
+
+# --- Allow HTTPS traffic to local Squid port ---
+SQUID_HTTPS_INPUT_COMMENT="Allow HTTPS from $HOTSPOT_NET on $WLAN_IF to local Squid 127.0.0.1:$SQUID_HTTPS_PORT"
+SQUID_HTTPS_INPUT_CMD="sudo nft add rule inet firewall_table input iifname \"$WLAN_IF\" ip saddr \"$HOTSPOT_NET\" ip daddr \"127.0.0.1\" tcp dport \"$SQUID_HTTPS_PORT\" accept comment \"$SQUID_HTTPS_INPUT_COMMENT\""
+
+if sudo nft list ruleset | grep -qF -- "$SQUID_HTTPS_INPUT_COMMENT"; then
+    echo "[INFO] Input rule for local Squid HTTPS traffic already seems to exist. Skipping."
+else
+    echo "[INFO] Adding INPUT rule for local Squid HTTPS traffic..."
+    eval "$SQUID_HTTPS_INPUT_CMD"
+    if [ $? -ne 0 ]; then echo "[ERROR] Failed to add INPUT rule for local Squid HTTPS. Exiting."; exit 1; fi
+    echo "[SUCCESS] INPUT rule for local Squid HTTPS added."
+fi
+
+echo ""
+echo "=== User Guidance ==="
+echo "Purpose of this script:"
+echo "  - To transparently redirect HTTP (port 80) and HTTPS (port 443) traffic from clients"
+echo "    on the '$WLAN_IF' network (subnet $HOTSPOT_NET) to the Squid proxy running locally"
+echo "    on ports $SQUID_HTTP_PORT (HTTP) and $SQUID_HTTPS_PORT (HTTPS)."
+echo "  - It includes bypass rules to ensure direct access to essential services on the RPi"
+echo "    itself (like the captive portal, local web admin, DNS, DHCP) is maintained."
+echo ""
+echo "Rule Order Considerations:"
+echo "  - Captive Portal First: It's assumed that 'setup_captive_portal_redirect_nft.sh' has"
+echo "    already run and its primary HTTP redirect rule is at 'position 0' in the"
+echo "    'ip nat_table prerouting' chain. This is crucial for unauthenticated users."
+echo "  - RPi Service Bypasses: The bypass rules in this script are inserted starting at 'position 1'"
+echo "    to ensure they are evaluated AFTER the main captive portal redirect but BEFORE the"
+echo "    general Squid DNAT rules. This prevents local RPi services from being proxied."
+echo "  - Squid DNAT Rules: These are appended, so they act as general fallbacks for web traffic"
+echo "    not caught by the portal redirect or specific RPi service bypasses."
+echo "  - INPUT Rules: These allow the traffic, once DNATed to 127.0.0.1, to be accepted by the RPi."
+echo ""
+echo "Interaction with Captive Portal:"
+echo "  - This script should typically be run AFTER users have authenticated through the"
+echo "    captive portal. The captive portal system would be responsible for:"
+echo "    1. Initially redirecting ALL HTTP traffic to itself (using the rule from"
+echo "       'setup_captive_portal_redirect_nft.sh')."
+echo "    2. Upon successful authentication, removing or disabling its own broad HTTP redirect rule"
+echo "       OR adding more specific rules to allow authenticated users to bypass the portal."
+echo "    3. The rules in THIS script then take over to proxy authenticated users' traffic via Squid."
+echo "  - If the main captive portal redirect (position 0) remains active and broadly matches all HTTP,"
+echo "    the Squid HTTP DNAT rule might not be hit for unauthenticated users. This is generally desired."
+echo ""
+echo "Persistence:"
+echo "  - These rules are temporary. To make them (and all other nftables rules) permanent:"
+echo "    1. After running ALL necessary setup scripts (NAT, portal, Squid redirect), save the"
+echo "       ENTIRE current ruleset:"
+echo "       sudo nft list ruleset > /etc/nftables.conf"
+echo "       (This command OVERWRITES /etc/nftables.conf. Review if you have existing rules.)"
+echo "    2. Ensure the nftables service is enabled to load rules at boot:"
+echo "       sudo systemctl enable nftables.service"
+echo "       sudo systemctl start nftables.service (or restart if already running)"
+echo ""
+echo "To view current rules: sudo nft list ruleset"
+echo ""
+echo "Squid proxy redirect setup script finished."
+
+exit 0

--- a/scripts/setup_captive_portal_redirect_nft.sh
+++ b/scripts/setup_captive_portal_redirect_nft.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# === Configuration ===
+# Network interface for the Wi-Fi Hotspot (LAN)
+# IMPORTANT: User MUST verify and change this to their actual WLAN interface
+WLAN_IF="wlan0"
+
+# IP Address of the Raspberry Pi on the WLAN interface
+# This is where the captive portal Nginx service is listening.
+# IMPORTANT: User MUST verify and change this to the RPi's actual IP on WLAN_IF
+RPI_WLAN_IP="192.168.73.1" # Example: Match this with your Pi-hole/DHCP setup for WLAN
+
+# Port where the Captive Portal Nginx is listening (Host Port from docker-compose)
+PORTAL_HOST_PORT="8080"
+
+# === Script Start ===
+echo "Starting Captive Portal Redirect Setup using nftables..."
+
+# Check if nftables is installed
+if ! command -v nft &> /dev/null; then
+    echo "[ERROR] nftables command could not be found. Please install nftables first."
+    echo "You can usually install it with: sudo apt update && sudo apt install nftables -y"
+    exit 1
+fi
+
+# Ensure base tables and chains are likely present (informational)
+echo "[INFO] This script assumes base tables 'inet firewall_table' and 'ip nat_table' exist,"
+echo "       and chains 'inet firewall_table input' and 'ip nat_table prerouting' exist."
+echo "       These are typically created by a base firewall script like 'setup_hotspot_nat_nft.sh'."
+
+# === 1. Add INPUT rule for Captive Portal Service ===
+# This rule allows clients on the WLAN to connect to the portal service on the RPi.
+INPUT_RULE_COMMENT="Allow TCP to Captive Portal on $RPI_WLAN_IP:$PORTAL_HOST_PORT from $WLAN_IF"
+INPUT_RULE_CMD="sudo nft add rule inet firewall_table input iifname \"$WLAN_IF\" ip daddr \"$RPI_WLAN_IP\" tcp dport \"$PORTAL_HOST_PORT\" accept comment \"$INPUT_RULE_COMMENT\""
+
+# Check if the INPUT rule or a similar one already exists to avoid duplicates
+if sudo nft list ruleset | grep -qF -- "$INPUT_RULE_COMMENT"; then
+    echo "[INFO] Input rule for captive portal service already seems to exist. Skipping addition."
+else
+    echo "[INFO] Adding INPUT rule for captive portal service..."
+    eval "$INPUT_RULE_CMD"
+    if [ $? -ne 0 ]; then
+        echo "[ERROR] Failed to add INPUT rule for captive portal. Exiting."
+        exit 1
+    fi
+    echo "[SUCCESS] INPUT rule added."
+fi
+
+# === 2. Add PREROUTING rule for HTTP Redirection ===
+# This rule redirects HTTP (port 80) traffic from any client on WLAN_IF
+# to the captive portal running on the RPi.
+# We only redirect traffic not already destined for the RPi itself to avoid loops.
+PREROUTING_RULE_COMMENT="DNAT HTTP from $WLAN_IF to Captive Portal $RPI_WLAN_IP:$PORTAL_HOST_PORT"
+# Using 'insert' to ensure high precedence for redirection.
+# It redirects traffic that is NOT already going to RPI_WLAN_IP to avoid loops if portal is on same IP.
+PREROUTING_RULE_CMD="sudo nft insert rule ip nat_table prerouting position 0 iifname \"$WLAN_IF\" ip daddr != \"$RPI_WLAN_IP\" tcp dport 80 dnat to \"$RPI_WLAN_IP:$PORTAL_HOST_PORT\" comment \"$PREROUTING_RULE_COMMENT\""
+
+# Check if the PREROUTING rule or a similar one already exists
+if sudo nft list ruleset | grep -qF -- "$PREROUTING_RULE_COMMENT"; then
+    echo "[INFO] Prerouting rule for HTTP redirection already seems to exist. Skipping addition."
+else
+    echo "[INFO] Adding PREROUTING rule for HTTP redirection..."
+    eval "$PREROUTING_RULE_CMD"
+    if [ $? -ne 0 ]; then
+        echo "[ERROR] Failed to add PREROUTING rule for HTTP redirection. Exiting."
+        exit 1
+    fi
+    echo "[SUCCESS] PREROUTING rule added."
+fi
+
+echo ""
+echo "=== User Guidance ==="
+echo "Purpose of this script:"
+echo "  - To redirect unauthenticated users on the '$WLAN_IF' network to the"
+echo "    captive portal running at $RPI_WLAN_IP:$PORTAL_HOST_PORT."
+echo "  - It allows access to the portal itself and then redirects HTTP traffic to it."
+echo ""
+echo "Limitations:"
+echo "  - HTTPS Redirection: This script ONLY redirects HTTP (port 80) traffic."
+echo "    Users trying to access HTTPS sites directly might see timeout errors or"
+echo "    certificate warnings if they haven't authenticated via an HTTP site first."
+echo "    Full HTTPS interception (like Squid with SSL Bump) is required for seamless"
+echo "    HTTPS redirection, which is complex and has security implications."
+echo "  - Persistent Redirection: Once these rules are active, HTTP traffic will"
+echo "    continue to be redirected until the rules are removed or modified."
+echo "    Your captive portal application should handle 'un-redirecting' clients"
+echo "    after they authenticate (e.g., by using firewall rules based on MAC/IP)."
+echo ""
+echo "Rule Order & Persistence:"
+echo "  - Rule Order: The PREROUTING rule for DNAT is inserted at 'position 0' to ensure"
+echo "    it's processed before other general NAT rules (like masquerading)."
+echo "    The INPUT rule for portal access is less sensitive to order but must exist."
+echo "  - Persistence: These rules are temporary. To make them (and all other nftables rules)"
+echo "    permanent and survive reboots:"
+echo "    1. After running ALL necessary setup scripts (NAT, portal, etc.), save the"
+echo "       ENTIRE current ruleset:"
+echo "       sudo nft list ruleset > /etc/nftables.conf"
+echo "       (This command OVERWRITES /etc/nftables.conf. Review if you have existing rules.)"
+echo "    2. Ensure the nftables service is enabled to load rules at boot:"
+echo "       sudo systemctl enable nftables.service"
+echo "       sudo systemctl start nftables.service (or restart if already running)"
+echo ""
+echo "To view current rules: sudo nft list ruleset"
+echo ""
+echo "Captive portal redirect setup script finished."
+
+exit 0

--- a/scripts/setup_hotspot_nat_nft.sh
+++ b/scripts/setup_hotspot_nat_nft.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# === Configuration ===
+# Network interface connected to the internet (WAN)
+# IMPORTANT: User MUST verify and change this to their actual Ethernet interface
+ETH_IF="eth0"
+
+# Network interface for the Wi-Fi Hotspot (LAN)
+# IMPORTANT: User MUST verify and change this to their actual WLAN interface
+WLAN_IF="wlan0"
+
+# Subnet for the Wi-Fi Hotspot
+HOTSPOT_NET="192.168.73.0/24"
+
+# === Script Start ===
+echo "Starting Hotspot NAT and Firewall Setup using nftables..."
+
+# 1. Enable IP Forwarding
+echo "[INFO] Enabling IP forwarding..."
+sudo sysctl -w net.ipv4.ip_forward=1
+if [ $? -ne 0 ]; then
+    echo "[ERROR] Failed to enable IP forwarding. Exiting."
+    exit 1
+fi
+
+# 2. Define nftables ruleset
+# Note: We will pipe this directly to nft.
+# For saving to a file, you would redirect this heredoc to a file.
+NFT_RULES=$(cat <<EOF
+# Flush all existing rules
+flush ruleset
+
+# === INET TABLE: firewall_table ===
+# This table handles general packet filtering.
+table inet firewall_table {
+    # --- INPUT CHAIN ---
+    # Handles incoming traffic to the Raspberry Pi itself.
+    # Default policy is DROP for security.
+    chain input {
+        type filter hook input priority 0; policy drop;
+
+        # Accept traffic from the loopback interface
+        iifname "lo" accept comment "Accept loopback traffic"
+
+        # Accept established and related connections
+        ct state established,related accept comment "Accept established/related connections"
+
+        # Allow DHCP requests from clients on the WLAN interface
+        iifname "\$WLAN_IF" udp dport 67 accept comment "Allow DHCP from WLAN"
+
+        # Allow DNS requests from clients on the WLAN interface (UDP and TCP)
+        iifname "\$WLAN_IF" udp dport 53 accept comment "Allow DNS (UDP) from WLAN"
+        iifname "\$WLAN_IF" tcp dport 53 accept comment "Allow DNS (TCP) from WLAN"
+
+        # Optional: Allow SSH access to the Pi from the WLAN interface (if needed for management)
+        # iifname "\$WLAN_IF" tcp dport 22 accept comment "Allow SSH from WLAN"
+    }
+
+    # --- FORWARD CHAIN ---
+    # Handles traffic passing through the Raspberry Pi (e.g., from WLAN to ETH).
+    # Default policy is DROP.
+    chain forward {
+        type filter hook forward priority 0; policy drop;
+
+        # Allow traffic from WLAN to ETH (hotspot clients to internet)
+        iifname "\$WLAN_IF" oifname "\$ETH_IF" accept comment "Forward WLAN to ETH"
+
+        # Allow established and related traffic back from ETH to WLAN
+        iifname "\$ETH_IF" oifname "\$WLAN_IF" ct state established,related accept comment "Forward established/related ETH to WLAN"
+    }
+}
+
+# === IP TABLE: nat_table ===
+# This table handles Network Address Translation (NAT).
+# We use 'ip' for NAT as 'inet' NAT is less common for simple masquerade.
+table ip nat_table {
+    # --- POSTROUTING CHAIN ---
+    # Handles traffic just before it leaves an interface.
+    # Used for Source NAT (SNAT/Masquerade).
+    chain postrouting {
+        type nat hook postrouting priority 100; # NF_IP_PRI_NAT_SRC
+
+        # Masquerade (NAT) traffic from the hotspot network going out the ETH interface
+        ip saddr \$HOTSPOT_NET oifname "\$ETH_IF" masquerade comment "Masquerade hotspot traffic to ETH"
+    }
+}
+EOF
+)
+
+# Substitute shell variables into the ruleset string
+# We need to be careful with escaping for sed and variable expansion
+NFT_RULES_SUBST=$(echo "$NFT_RULES" | \
+    sed "s/\\\$WLAN_IF/$WLAN_IF/g; s/\\\$ETH_IF/$ETH_IF/g; s/\\\$HOTSPOT_NET/$HOTSPOT_NET/g")
+
+# 3. Apply nftables ruleset
+echo "[INFO] Applying nftables ruleset..."
+echo "${NFT_RULES_SUBST}" | sudo nft -f -
+if [ $? -ne 0 ]; then
+    echo "[ERROR] Failed to apply nftables ruleset. Exiting."
+    # Display the rules that were attempted, for debugging
+    echo "--- Attempted Ruleset ---"
+    echo "${NFT_RULES_SUBST}"
+    echo "-------------------------"
+    exit 1
+fi
+
+echo "[SUCCESS] nftables ruleset applied successfully."
+
+# 4. User Guidance for Persistence
+echo ""
+echo "=== IMPORTANT NEXT STEPS ==="
+echo "1. VERIFY INTERFACES:"
+echo "   The script used ETH_IF='${ETH_IF}' and WLAN_IF='${WLAN_IF}'."
+echo "   If these are incorrect, please edit this script and re-run it."
+echo "   You can find your interface names using 'ip a' or 'ifconfig'."
+echo ""
+echo "2. PERSISTENCE (Making rules survive reboots):"
+echo "   The current rules are temporary and will be lost on reboot."
+echo "   To make them permanent:"
+echo "   a. Ensure nftables is installed: 'sudo apt update && sudo apt install nftables -y'"
+echo "   b. Save the current (working) ruleset:"
+echo "      sudo nft list ruleset > /etc/nftables.conf"
+echo "      (This command overwrites /etc/nftables.conf. Review existing content if any.)"
+echo "   c. Enable the nftables service to load rules at boot:"
+echo "      sudo systemctl enable nftables.service"
+echo "      sudo systemctl start nftables.service"
+echo ""
+echo "3. CHECK STATUS:"
+echo "   sudo nft list ruleset"
+echo "   sudo systemctl status nftables.service"
+echo ""
+echo "Setup complete. Your hotspot NAT and firewall should now be active."
+echo "Remember to configure your DHCP server (e.g., dnsmasq or isc-dhcp-server)"
+echo "to serve addresses on the ${WLAN_IF} interface in the ${HOTSPOT_NET} range,"
+echo "and to provide this Raspberry Pi's ${WLAN_IF} IP as the gateway and DNS server."
+
+exit 0

--- a/squid_Berezino_Checkpoint/README_SQUID.md
+++ b/squid_Berezino_Checkpoint/README_SQUID.md
@@ -7,13 +7,13 @@ This guide provides instructions for setting up the `Berezino_Checkpoint` Squid 
 1.  **`squid_Berezino_Checkpoint/docker-compose.yml`**: Docker Compose configuration to run Squid.
 2.  **`squid_Berezino_Checkpoint/squid.conf`**: Custom configuration for Squid, enabling transparent proxying and SSL bumping.
 3.  **`squid_Berezino_Checkpoint/certs/`**: Directory to store your SSL CA certificate (you must create this).
-4.  **`scripts/redirect_to_squid.sh`**: Script to set up `iptables` rules for redirecting hotspot traffic to Squid.
+4.  **`scripts/redirect_to_squid_nft.sh`**: Script to set up `nftables` rules for redirecting hotspot traffic to Squid.
 
 ## I. Prerequisites
 
 *   Ensure Docker and Docker Compose are installed on your Raspberry Pi 5.
 *   Ensure the Wi-Fi hotspot (`rpi` SSID on `wlan0`, network `192.168.73.0/24`) is operational as per the previous `Chernarus_Beacon` setup.
-*   The NAT script (`scripts/setup_hotspot_nat.sh`) from the hotspot setup should already be in place and configured to allow general internet access for hotspot clients.
+*   The NAT script (`scripts/setup_hotspot_nat_nft.sh`) from the hotspot setup should already be in place and configured to allow general internet access for hotspot clients.
 *   Create the necessary directories on your Raspberry Pi for persistent Squid data, ensuring they have appropriate permissions for the user/group running Docker (or make them world-writable if unsure, though less secure for production):
     ```bash
     sudo mkdir -p /mnt/usbdata/Berezino_Checkpoint/cache
@@ -92,36 +92,37 @@ The `squid_Berezino_Checkpoint/docker-compose.yml` file defines the Squid servic
     ```
     Look for any errors in the logs. If Squid starts correctly, it should indicate it's ready to accept connections on ports 3128 and 3129.
 
-## V. `iptables` Traffic Redirection
+## V. `nftables` Traffic Redirection
 
-To transparently redirect traffic from hotspot clients to the Squid proxy running in Docker, you need to apply `iptables` rules on the Raspberry Pi host.
+To transparently redirect traffic from hotspot clients to the Squid proxy running in Docker, you need to apply `nftables` rules on the Raspberry Pi host.
 
 1.  **Locate the Script:**
-    The script `scripts/redirect_to_squid.sh` (from the main `scripts` directory in your cloned repository) is designed for this.
+    The script `scripts/redirect_to_squid_nft.sh` (from the main `scripts` directory in your cloned repository) is designed for this.
 
 2.  **Make it Executable:**
     ```bash
-    chmod +x path/to/your/cloned/repository/scripts/redirect_to_squid.sh
+    chmod +x path/to/your/cloned/repository/scripts/redirect_to_squid_nft.sh
     ```
 
 3.  **Run the Script:**
     Execute it with `sudo` privileges:
     ```bash
-    sudo path/to/your/cloned/repository/scripts/redirect_to_squid.sh
+    sudo path/to/your/cloned/repository/scripts/redirect_to_squid_nft.sh
     ```
-    This script adds rules to the `nat` table's `PREROUTING` chain to redirect HTTP (port 80) and HTTPS (port 443) traffic from `wlan0` clients to Squid's respective ports (3128 and 3129) on the host machine.
+    This script adds rules to the `nat` table's `prerouting` chain (or a similarly named table/chain if you've customized `setup_hotspot_nat_nft.sh`) to redirect HTTP (port 80) and HTTPS (port 443) traffic from `wlan0` clients to Squid's respective ports (3128 and 3129) on the host machine (127.0.0.1).
 
 4.  **Docker Networking and `127.0.0.1`:**
-    The `iptables` rules redirect traffic to `127.0.0.1` (localhost) on the Raspberry Pi. Docker, through its port mappings defined in `docker-compose.yml` (e.g., `ports: - "3128:3128"`), makes the Squid container's ports accessible on the host's `127.0.0.1` interface. This is a standard method for redirecting host traffic to a Docker container.
-    The script also includes rules to allow traffic *to* the Pi-hole/RPi itself on `wlan0` (DNS, DHCP, captive portal) to bypass this redirection.
+    The `nftables` rules redirect traffic to `127.0.0.1` (localhost) on the Raspberry Pi. Docker, through its port mappings defined in `docker-compose.yml` (e.g., `ports: - "3128:3128"`), makes the Squid container's ports accessible on the host's `127.0.0.1` interface. This is a standard method for redirecting host traffic to a Docker container.
+    The script also includes rules to allow traffic *to* the Pi-hole/RPi itself on `wlan0` (DNS, DHCP, captive portal) to bypass this redirection. These are added as `return` rules in the `prerouting` chain before the main Squid DNAT rules.
 
-5.  **Persistence:**
-    The `iptables` rules are volatile and will be lost on reboot.
-    *   If you installed `iptables-persistent` during the hotspot setup, save the current rules:
+5.  **Persistence (`nftables`):**
+    The `nftables` rules are volatile and will be lost on reboot unless saved.
+    *   Ensure `nftables` service is enabled: `sudo systemctl enable nftables.service`.
+    *   After running all necessary `nftables` scripts (`setup_hotspot_nat_nft.sh`, `setup_captive_portal_redirect_nft.sh`, and this `redirect_to_squid_nft.sh`) in the correct order and verifying functionality, save the complete ruleset:
         ```bash
-        sudo netfilter-persistent save
+        sudo nft list ruleset > /etc/nftables.conf
         ```
-    *   If you modify rules or run other `iptables` scripts, remember to re-save.
+    *   If you modify rules or re-run any `nftables` scripts, remember to save the complete, working ruleset again to `/etc/nftables.conf`.
 
 ## VI. Testing and Verification
 
@@ -147,7 +148,11 @@ To stop the Squid proxy:
 cd path/to/your/cloned/repository/squid_Berezino_Checkpoint/
 docker-compose down
 ```
-Remember that `iptables` rules will remain until reboot or manually flushed/removed. If you stop Squid, you might want to remove or disable the redirection rules to restore direct internet access for hotspot clients.
+Remember that `nftables` rules will remain until reboot or manually flushed/removed. If you stop Squid, you might want to remove or disable the redirection rules to restore direct internet access for hotspot clients. This can be done by:
+1.  Identifying the Squid redirection rules (e.g., via `sudo nft list ruleset -a` to get handles).
+2.  Deleting them using their handles (e.g., `sudo nft delete rule ip nat_table prerouting handle <handle>`).
+3.  Or, by editing `/etc/nftables.conf` to remove the rules and then reloading with `sudo systemctl reload nftables.service`.
+Always save the desired ruleset to `/etc/nftables.conf` afterwards.
 
 ## Troubleshooting:
 
@@ -161,12 +166,12 @@ Remember that `iptables` rules will remain until reboot or manually flushed/remo
     *   The `myCA.pem` used by Squid is different from the `myCA.crt` distributed to clients.
     *   `ssl_bump` rules in `squid.conf` are misconfigured.
 *   **No Internet on Clients:**
-    *   `iptables` redirection rules are incorrect or not applied.
+    *   `nftables` redirection rules are incorrect or not applied. Check with `sudo nft list ruleset`.
     *   Squid is not running or not accessible.
-    *   Outbound internet connectivity for Squid itself is blocked (check Raspberry Pi's main FORWARD rules and NAT setup from `setup_hotspot_nat.sh`).
+    *   Outbound internet connectivity for Squid itself is blocked (check Raspberry Pi's main `nftables` FORWARD rules and NAT setup from `setup_hotspot_nat_nft.sh`).
     *   DNS resolution is failing for Squid (ensure `dns_nameservers 192.168.73.1` in `squid.conf` is correct and Pi-hole is working).
 *   **Traffic Not Being Logged by Squid:**
-    *   `iptables` rules are not correctly redirecting traffic.
+    *   `nftables` rules are not correctly redirecting traffic. Check with `sudo nft list ruleset`.
     *   `acl localnet` in `squid.conf` does not match your hotspot network.
 *   **Performance Issues:**
     *   Transparent proxying, especially SSL bumping, adds overhead. The Raspberry Pi 5 should handle a small number of clients, but monitor CPU/memory usage.

--- a/squid_Berezino_Checkpoint/squid.conf
+++ b/squid_Berezino_Checkpoint/squid.conf
@@ -6,7 +6,7 @@ http_port 3128 transparent
 # User MUST generate a CA certificate (e.g., myCA.pem) and private key (myCA.key)
 # and place them in the ./certs directory mapped in docker-compose.yml
 # The .pem should contain both cert and key or use cert= and key= separately.
-https_port 3129 intercept ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=4MB cert=/etc/squid/certs/myCA.pem key=/etc/squid/certs/myCA.key
+https_port 3129 intercept ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=4MB cert=/etc/squid/certs/myCA.pem
 
 # Define SSL bump actions
 # Step 1: Peek at the SNI

--- a/wiki/es/10-Arranque-y-Pruebas.md
+++ b/wiki/es/10-Arranque-y-Pruebas.md
@@ -1,0 +1,141 @@
+# Plan de Pruebas y Verificación del Sistema
+
+Este documento describe el plan de pruebas conceptual para el sistema "Operación: The Perimeter". Cada fase de prueba asume que las fases anteriores han sido completadas y verificadas exitosamente.
+
+## I. Entorno de Pruebas
+
+*   **Hardware:** Raspberry Pi 5 con adaptador Wi-Fi funcional (para `wlan0`), conectado a internet a través de `eth0` (o interfaz WAN configurada).
+*   **Software:** Raspberry Pi OS (actualizado), Pi-hole (instalado en el host), Docker, Docker Compose, Python 3, `requests` (Python), `nftables`, `hostapd`, `curl`, `jq`.
+*   **Cliente de Pruebas:** Un dispositivo con Wi-Fi (laptop, smartphone) para conectarse al hotspot.
+*   **Configuraciones del Proyecto:** Clonadas desde el repositorio (`/opt/surviving-chernarus`), con los scripts y archivos de configuración relevantes aplicados.
+
+## II. Prerrequisitos Generales para las Pruebas
+
+1.  **Raspberry Pi Configurado:** IP estática en `eth0` (si aplica) y `wlan0` (`192.168.73.1`).
+2.  **Pi-hole (Host) Instalado y Funcionando:** Pi-hole instalado en el sistema operativo base del Raspberry Pi y funcionando como resolvedor DNS para el propio Pi y la red del hotspot. La configuración de DHCP para `wlan0` y el DNS personalizado para `*.terrerov.com` están aplicados (`/etc/dnsmasq.d/02-chernarus-hotspot-dhcp.conf`, `/etc/dnsmasq.d/03-terrerov-domain.conf`).
+3.  **Servicios Base Activos:** `hostapd` configurado y activo. Docker service activo.
+4.  **Variables de Entorno Configuradas:** El archivo `.env` en la raíz del proyecto (`/opt/surviving-chernarus/.env`) está creado a partir de `.env.example` y contiene los valores correctos para `PIHOLE_WEBPASSWORD`, `TZ`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_NAME`, y `CLOUDFLARE_RECORD_NAME`.
+5.  **Scripts `nftables` Aplicados:** Los scripts de `nftables` (`/opt/surviving-chernarus/scripts/setup_hotspot_nat_nft.sh`, `/opt/surviving-chernarus/scripts/setup_captive_portal_redirect_nft.sh`, `/opt/surviving-chernarus/scripts/redirect_to_squid_nft.sh`) han sido ejecutados en el orden correcto.
+6.  **Reglas `nftables` Persistentes:** El conjunto de reglas de `nftables` ha sido guardado en `/etc/nftables.conf` y el servicio `nftables` está habilitado para cargar las reglas al arranque (`sudo systemctl enable nftables.service`).
+7.  **Contenedores Docker en Ejecución:** Los contenedores Docker para `chernarus_entrypoint` (Nginx portal), `berezino_checkpoint` (Squid), y `pihole` (Pi-hole Dockerizado, si se mantiene para pruebas de `.env`) están en ejecución.
+8.  **Certificado CA Generado y Distribuido:** El certificado CA (`myCA.pem`) ha sido generado y colocado en `squid_Berezino_Checkpoint/certs/`. Una copia del certificado público (`myCA.crt` o el mismo `.pem` si es solo el cert público) está en `captive_portal_Chernarus_Entrypoint/html/` y el enlace en `index.html` es correcto.
+
+## III. Casos de Prueba Detallados
+
+---
+**Test Case 1: Conexión al Hotspot Wi-Fi (`Chernarus_Beacon`)**
+*   **Pasos:**
+    1.  En el dispositivo cliente, buscar redes Wi-Fi.
+    2.  Conectarse al SSID `rpi` (o el configurado en `hostapd.conf`) usando la contraseña definida.
+*   **Resultados Esperados:**
+    1.  El cliente se conecta exitosamente a la red Wi-Fi.
+    2.  El cliente recibe una dirección IP del rango `192.168.73.10` - `192.168.73.200`.
+    3.  El cliente recibe `192.168.73.1` como la dirección del gateway y del servidor DNS.
+
+---
+**Test Case 2: Funcionalidad Básica de Red (NAT y DNS del Host)**
+*   **Pasos:**
+    1.  Con un cliente conectado al hotspot, intentar hacer ping a una IP externa (ej. `8.8.8.8`).
+    2.  Intentar resolver un dominio público (ej. `ping google.com`).
+*   **Resultados Esperados:**
+    1.  El ping a `8.8.8.8` es exitoso (NAT funciona).
+    2.  `google.com` se resuelve y el ping es exitoso (DNS del host y NAT funcionan).
+
+---
+**Test Case 3: Verificación de Reglas `nftables`**
+*   **Pasos:**
+    1.  En la Raspberry Pi, ejecutar `sudo nft list ruleset`.
+*   **Resultados Esperados:**
+    1.  El output refleja las reglas intencionadas por `setup_hotspot_nat_nft.sh`, `setup_captive_portal_redirect_nft.sh`, y `redirect_to_squid_nft.sh`.
+    2.  **Tablas y Cadenas:** Existencia de tablas (ej. `firewall_table`, `nat_table`) y cadenas (`input`, `forward`, `prerouting`, `postrouting`) con sus políticas base correctas.
+    3.  **Reglas de Input (firewall_table):**
+        *   Aceptar tráfico en `lo`.
+        *   Aceptar `ct state established,related`.
+        *   Aceptar DHCP (udp dport 67) en `WLAN_IF` (variable del script, ej. `wlan0`).
+        *   Aceptar DNS (udp/tcp dport 53) en `WLAN_IF`.
+        *   Aceptar TCP al puerto del portal (ej. 8080) en `RPI_WLAN_IP` (variable del script, ej. `192.168.73.1`) desde `WLAN_IF`.
+        *   Aceptar TCP a los puertos de Squid (ej. 3128, 3129) en `127.0.0.1` desde `WLAN_IF`.
+    4.  **Reglas de Forward (firewall_table):**
+        *   Aceptar tráfico de `WLAN_IF` a `ETH_IF` (variables del script).
+        *   Aceptar `ct state established,related` de `ETH_IF` a `WLAN_IF`.
+    5.  **Reglas de NAT Prerouting (nat_table):**
+        *   DNAT para redirección HTTP al portal (ej. `iifname "wlan0" tcp dport 80 dnat to 192.168.73.1:8080`) con alta precedencia (insertado al principio).
+        *   Reglas `return` para bypass de servicios locales en `RPI_WLAN_IP` (DNS, DHCP, Portal) antes de las reglas de Squid.
+        *   DNAT para redirección HTTP a Squid (ej. `iifname "wlan0" ip daddr != 192.168.73.1 tcp dport 80 dnat to 127.0.0.1:3128`).
+        *   DNAT para redirección HTTPS a Squid (ej. `iifname "wlan0" ip daddr != 192.168.73.1 tcp dport 443 dnat to 127.0.0.1:3129`).
+    6.  **Reglas de NAT Postrouting (nat_table):**
+        *   Regla de `masquerade` para el tráfico saliente de `HOTSPOT_NET` (variable del script, ej. `192.168.73.0/24`) por `ETH_IF`.
+
+---
+**Test Case 4: Redirección al Portal Cautivo (`Chernarus_Entrypoint`)**
+*   **Pasos:**
+    1.  Con un cliente nuevo, intentar acceder a un sitio web **HTTP** (ej. `http://neverssl.com`).
+*   **Resultados Esperados:**
+    1.  Redirección al portal cautivo (`http://192.168.73.1:8080`).
+    2.  Página del portal visible con enlace de descarga del certificado.
+
+---
+**Test Case 5: Descarga e Instalación del Certificado CA**
+*   **Pasos:**
+    1.  Desde el portal, descargar el certificado CA.
+    2.  Instalar y confiar en el certificado en el cliente.
+*   **Resultados Esperados:**
+    1.  Descarga correcta.
+    2.  Instalación y confianza sin errores.
+
+---
+**Test Case 6: Proxy Transparente Squid (`Berezino_Checkpoint`) para HTTPS**
+*   **Pasos:**
+    1.  Con cliente con CA confiable, acceder a un sitio **HTTPS** (ej. `https://google.com`).
+    2.  Verificar certificado del sitio en el navegador.
+    3.  Monitorear logs de Squid (`sudo docker logs -f Berezino_Checkpoint`).
+*   **Resultados Esperados:**
+    1.  Sitio HTTPS carga sin advertencias.
+    2.  Emisor del certificado es "BerezinoCheckpointCA".
+    3.  Logs de Squid muestran "bump" para conexiones HTTPS.
+
+---
+**Test Case 7: Resolución DNS vía Pi-hole del Host y Dominio Personalizado (`*.terrerov.com`)**
+*   **Pasos:**
+    1.  En el cliente, realizar consultas DNS para dominios públicos (ej. `google.com`).
+    2.  Verificar logs de consulta en la interfaz web del Pi-hole del **host**.
+    3.  Intentar resolver `test.terrerov.com` y `another.terrerov.com` (usando `ping`, `nslookup`, `dig`).
+*   **Resultados Esperados:**
+    1.  Dominios públicos se resuelven.
+    2.  Consultas DNS aparecen en logs del Pi-hole del host.
+    3.  `test.terrerov.com` y `another.terrerov.com` resuelven a `192.168.73.1`.
+
+---
+**Test Case 8: Verificación Script DDNS de Cloudflare**
+*   **Pasos:**
+    1.  Verificar que `.env` tiene `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_NAME`, `CLOUDFLARE_RECORD_NAME`.
+    2.  Ejecutar manualmente: `source /opt/surviving-chernarus/.env && python3 /opt/surviving-chernarus/scripts/cloudflare_ddns.py`.
+    3.  Observar salida del script.
+    4.  Verificar registro DNS 'A' en el panel de Cloudflare.
+    5.  (Opcional avanzado) Simular cambio de IP pública y re-ejecutar.
+    6.  Verificar configuración del cron job (ej. `sudo crontab -l`).
+*   **Resultados Esperados:**
+    1.  Script informa éxito o IP sin cambios.
+    2.  Registro DNS 'A' en Cloudflare coincide con IP pública del RPi.
+    3.  (Opcional) Registro se actualiza tras cambio simulado de IP.
+    4.  Cron job configurado según documentación.
+
+---
+**Test Case 9: Verificación de Configuración Centralizada (`.env`)**
+*   **Pasos:**
+    1.  Modificar `PIHOLE_WEBPASSWORD` en `.env`.
+    2.  Reiniciar contenedor Pi-hole Dockerizado (si se usa para este test): `cd /opt/surviving-chernarus && sudo docker-compose restart pihole` (asumiendo `pihole` es el nombre del servicio en un docker-compose unificado o el específico del Pi-hole Dockerizado).
+    3.  Probar login en interfaz web del Pi-hole **Dockerizado** (`http://192.168.73.1:8081/admin/`, si el puerto está mapeado) con nueva contraseña.
+    4.  (Conceptual) Cambiar `CLOUDFLARE_RECORD_NAME` en `.env`. Ejecutar DDNS y verificar que opera sobre el nuevo registro.
+*   **Resultados Esperados:**
+    1.  Login en Pi-hole Dockerizado funciona con nueva contraseña.
+    2.  Script DDNS usa nuevos valores de `.env`.
+
+---
+## IV. Pruebas de Estrés y Larga Duración (Conceptuales)
+
+*   **Conexión de Múltiples Clientes:** Conectar varios dispositivos, verificar estabilidad y rendimiento.
+*   **Uso Continuado:** Dejar sistema funcionando 24-48h con tráfico normal, verificar estabilidad, logs.
+*   **Reinicios:** Verificar que servicios y reglas `nftables` se restauran tras reinicio del RPi.
+
+Este plan de pruebas cubre las funcionalidades clave. Ajustes pueden ser necesarios.

--- a/wiki/es/15-Configurar-DDNS-Cloudflare.md
+++ b/wiki/es/15-Configurar-DDNS-Cloudflare.md
@@ -1,0 +1,122 @@
+# Configurar DDNS Dinámico con Cloudflare
+
+## 1. Introducción/Propósito
+
+El script `cloudflare_ddns.py` está diseñado para mantener actualizado un registro DNS 'A' en Cloudflare con la dirección IP pública dinámica de tu Raspberry Pi (o cualquier máquina donde se ejecute). Esto es útil si tu proveedor de internet te asigna direcciones IP que cambian con el tiempo, permitiéndote tener un nombre de dominio fijo (ej. `rpi.terrerov.com`) que siempre apunte a tu red local.
+
+El script:
+1. Obtiene la dirección IP pública actual de la máquina.
+2. Comprueba el registro DNS 'A' configurado en Cloudflare.
+3. Si la IP pública ha cambiado, actualiza el registro DNS en Cloudflare con la nueva IP.
+
+## 2. Dependencias/Prerrequisitos
+
+Antes de configurar y ejecutar el script, asegúrate de tener lo siguiente:
+
+*   **Python 3:** Instalado en el sistema donde se ejecutará el script (generalmente tu Raspberry Pi).
+    ```bash
+    sudo apt update
+    sudo apt install python3
+    ```
+*   **Librería `requests` de Python:** Necesaria para realizar peticiones HTTP a los servicios de IP y a la API de Cloudflare.
+    ```bash
+    pip3 install requests
+    ```
+    O, si prefieres usar `apt` para la versión del sistema (puede ser más antigua):
+    ```bash
+    sudo apt install python3-requests
+    ```
+*   **Cuenta de Cloudflare y Dominio:** Debes tener una cuenta activa en [Cloudflare](https://www.cloudflare.com/) y un dominio (ej. `terrerov.com`) añadido y gestionado a través de sus servicios.
+*   **Registro DNS 'A' (Recomendado):** Es ideal que el registro DNS 'A' que deseas actualizar (ej. `rpi.terrerov.com`) ya esté creado en tu panel de Cloudflare. Si el script no lo encuentra, mostrará una advertencia y no intentará crearlo automáticamente (requiere creación manual la primera vez).
+
+## 3. Obtención del Token de API de Cloudflare
+
+Para que el script pueda interactuar con tu cuenta de Cloudflare de forma segura, necesitas generar un Token de API con permisos específicos.
+
+1.  **Inicia sesión en Cloudflare:** Ve a [dash.cloudflare.com](https://dash.cloudflare.com).
+2.  **Ve a "My Profile":** Haz clic en el icono de perfil en la esquina superior derecha.
+3.  **Selecciona "API Tokens":** En el menú lateral izquierdo de tu perfil.
+4.  **Haz clic en "Create Token".**
+5.  **Usa una plantilla (recomendado) o crea uno personalizado:**
+    *   La opción más sencilla es buscar la plantilla "Edit zone DNS". Si no la encuentras, puedes crear uno personalizado.
+    *   Para un **token personalizado**, asígnale un nombre descriptivo (ej. "DDNS_Token_RPi").
+6.  **Configura los Permisos:**
+    *   **Permissions:**
+        *   Selecciona `Zone`
+        *   Selecciona `DNS`
+        *   Selecciona `Edit`
+    *   **Zone Resources:**
+        *   Selecciona `Include`
+        *   Selecciona `Specific zone`
+        *   Elige el dominio que quieres gestionar (ej. `terrerov.com`).
+    *   Puedes dejar "Client IP Address Filtering" y "TTL" con sus valores predeterminados o ajustarlos si tienes necesidades específicas de seguridad.
+7.  **Haz clic en "Continue to summary".**
+8.  **Revisa los permisos y haz clic en "Create Token".**
+9.  **¡COPIA EL TOKEN INMEDIATAMENTE!** Cloudflare te mostrará el token generado. Cópialo y guárdalo en un lugar seguro. **No podrás verlo de nuevo.** Este token es el que usarás para la variable de entorno `CLOUDFLARE_API_TOKEN`.
+
+## 4. Configuración del Script (Variables de Entorno)
+
+El script `cloudflare_ddns.py` se configura mediante las siguientes tres variables de entorno:
+
+*   `CLOUDFLARE_API_TOKEN`: Pega aquí el token de API que generaste en el paso anterior.
+*   `CLOUDFLARE_ZONE_NAME`: Es el nombre de tu dominio gestionado en Cloudflare. Por ejemplo, si tu dominio es `terrerov.com`, ese es el valor.
+*   `CLOUDFLARE_RECORD_NAME`: Es el nombre completo del registro 'A' que quieres actualizar. Por ejemplo, si quieres que `rpi.terrerov.com` apunte a tu IP, este sería el valor. Si quieres actualizar el registro raíz (ej. `terrerov.com` directamente), usarías `terrerov.com`.
+
+Estas variables se gestionarán de forma centralizada en el proyecto a través de un archivo `.env` ubicado en `/opt/surviving-chernarus/.env`. El script de ejecución periódica (cron job) se encargará de cargar estas variables desde dicho archivo.
+
+## 5. Ejecución Manual del Script
+
+Para probar el script manualmente, primero asegúrate de que las variables de entorno estén definidas en tu sesión actual o carga el archivo `.env`.
+
+**Opción 1: Exportar variables temporalmente**
+```bash
+export CLOUDFLARE_API_TOKEN="tu_api_token_aqui"
+export CLOUDFLARE_ZONE_NAME="terrerov.com"
+export CLOUDFLARE_RECORD_NAME="rpi.terrerov.com"
+python3 /opt/surviving-chernarus/scripts/cloudflare_ddns.py
+```
+
+**Opción 2: Cargar desde .env y ejecutar (recomendado para pruebas si .env ya está configurado)**
+```bash
+# Suponiendo que estás en el directorio /opt/surviving-chernarus/
+source .env
+python3 scripts/cloudflare_ddns.py
+```
+
+El script imprimirá información sobre su progreso, incluyendo la IP pública detectada, la IP actual en Cloudflare y si se necesita o no una actualización.
+
+## 6. Ejecución Periódica (Cron Job)
+
+Para que el script se ejecute automáticamente y mantenga tu DNS actualizado, puedes configurar un cron job.
+
+1.  Abre la tabla de cron para el usuario `root` (o el usuario que deba ejecutar el script, asegurándote de que tenga acceso a Python, al script y al archivo `.env`):
+    ```bash
+    sudo crontab -e
+    ```
+2.  Añade la siguiente línea al final del archivo para ejecutar el script cada 15 minutos:
+
+    ```cron
+    */15 * * * * bash -c 'source /opt/surviving-chernarus/.env && /usr/bin/python3 /opt/surviving-chernarus/scripts/cloudflare_ddns.py' >> /var/log/cloudflare_ddns.log 2>&1
+    ```
+
+    **Desglose del comando cron:**
+    *   `*/15 * * * *`: Define la frecuencia (cada 15 minutos).
+    *   `bash -c '...'`: Ejecuta el comando dentro de las comillas simples usando bash. Esto es útil para encadenar comandos como `source` y la ejecución del script.
+    *   `source /opt/surviving-chernarus/.env`: Carga las variables de entorno desde el archivo `.env` antes de ejecutar el script. **Asegúrate de que la ruta al archivo `.env` sea correcta.**
+    *   `/usr/bin/python3 /opt/surviving-chernarus/scripts/cloudflare_ddns.py`: Ruta completa al intérprete de Python 3 y al script. **Verifica estas rutas en tu sistema.**
+    *   `>> /var/log/cloudflare_ddns.log 2>&1`: Redirige tanto la salida estándar (stdout) como la salida de error (stderr) al archivo de log `/var/log/cloudflare_ddns.log`. Esto es crucial para el seguimiento y la depuración.
+
+3.  Guarda y cierra el archivo. El cron job se activará automáticamente.
+
+## 7. Logging (Registro)
+
+Como se mencionó anteriormente, el script `cloudflare_ddns.py` imprime mensajes informativos y de error a la salida estándar (stdout) y a la salida de error estándar (stderr).
+
+Cuando se ejecuta mediante el cron job configurado en el ejemplo anterior:
+*   Toda la salida se redirige al archivo `/var/log/cloudflare_ddns.log`.
+*   Puedes revisar este archivo para verificar que el script se está ejecutando correctamente, ver las IPs detectadas y cualquier error que pueda haber ocurrido.
+    ```bash
+    tail -f /var/log/cloudflare_ddns.log
+    ```
+
+Es recomendable revisar este log periódicamente, especialmente después de la configuración inicial, para asegurar el correcto funcionamiento del sistema DDNS.


### PR DESCRIPTION
I've made a major overhaul of the firewall system, migrating from iptables to nftables. This introduces three new nftables scripts:
- setup_hotspot_nat_nft.sh
- setup_captive_portal_redirect_nft.sh
- redirect_to_squid_nft.sh

I've also added a Cloudflare Dynamic DNS (DDNS) Python script (`cloudflare_ddns.py`) to automatically update a DNS 'A' record with the RPi's public IP. I've included documentation for setting up and using the DDNS script.

Additionally, I've implemented a centralized configuration system using a `.env` file for managing API keys, passwords, and environment-specific variables. I've updated docker-compose.yml to use these variables and provided an `.env.example` template.

I've enhanced Pi-hole (host) DNS capabilities by adding a custom dnsmasq configuration to resolve `*.terrerov.com` to the RPi's local IP.

Finally, I've updated all relevant documentation (READMEs, wiki pages) to reflect these significant changes, including new package dependencies, script execution order, and testing procedures. I've also resolved a potential DNS port conflict for the Dockerized Pi-hole by removing its port 53 mapping.